### PR TITLE
Empty semver packages generate a blank page issue

### DIFF
--- a/src/components/VersionSelect.tsx
+++ b/src/components/VersionSelect.tsx
@@ -128,7 +128,10 @@ export const VersionSelect = ({
     const safeCompareVersions = (v1: string, v2: string) => {
       const safeV1 = (coerce(v1) || "").toString();
       const safeV2 = (coerce(v2) || "").toString();
-      return compareVersions(safeV1, safeV2);
+
+      // Be sure both versions are not empty before calling the compareVersions method,
+      // in order to avoid the 'Invalid argument not valid semver'
+      return safeV1 && safeV2 ? compareVersions(safeV1, safeV2) : 1;
     };
     sortedVersions = result.sort(safeCompareVersions);
 

--- a/test/components/VersionSelect.test.tsx
+++ b/test/components/VersionSelect.test.tsx
@@ -20,6 +20,9 @@ jest.mock(
             },
             {
               version: "0.5.0.pre" // Real-world example: pyarrow 0.5.0.pre
+            },
+            {
+              version: "2023.01.10" // Real-world example: ca-certificates 2023.01.10
             }
           ]
         }


### PR DESCRIPTION
I was able to replicate the [Editor page goes blank issue](https://github.com/Quansight/conda-store/issues/458). I figured out there are some packages, like the `ca-certificates` one, that generate the issue.

Once I updated the [VersionSelect](https://github.com/Quansight/conda-store-ui/blob/main/test/components/VersionSelect.test.tsx) unit test with the `ca-certificates` array versions:

```
jest.mock(
  "../../src/features/requestedPackages/requestedPackageVersionApiSlice",
  () => ({
    useLazyGetPackageVersionSuggestionsQuery: jest.fn(() => [
      () => ({
        data: {
          data: [
            {
              id: 504014,
              channel: {
                id: 3,
                name: "https://repo.anaconda.com/pkgs/main",
                last_update: null
              },
              build: "h06a4308_0",
              license: "MPL-2.0",
              sha256:
                "f6c2cb1b849ce96efa34839533f135a8030db23fcff7f583270d518bb86e713f",
              name: "ca-certificates",
              version: "2023.01.10",
              summary: "Certificates for use with other packages."
            },
            {
              id: 463644,
              channel: {
                id: 2,
                name: "https://conda.anaconda.org/conda-forge",
                last_update: null
              },
              build: "ha878542_0",
              license: "ISC",
              sha256:
                "058355034667e77d15389700f6b2364cc74efce0af63a418eacc1ce252458942",
              name: "ca-certificates",
              version: "2022.9.24",
              summary: "Certificates for use with other packages."
            },
            {
              id: 460350,
              channel: {
                id: 2,
                name: "https://conda.anaconda.org/conda-forge",
                last_update: null
              },
              build: "ha878542_0",
              license: "ISC",
              sha256:
                "26a1a2d9e63440ec3b2a59297d47f7d5b405a3caab61bf93648e1621a46bb05a",
              name: "ca-certificates",
              version: "2022.9.14",
              summary: "Certificates for use with other packages."
            }
          ]
        }
      })
    ])
  })
);
```

I got the same error mentioned above:

![Screenshot 2023-04-26 at 2 37 37 PM](https://user-images.githubusercontent.com/5192743/234684320-7bfd6879-8dd6-4c96-a1a0-82baebcfcb8d.png)

The fix is to validate that the semver value is not empty before making the comparison:

![Screenshot 2023-04-26 at 2 41 08 PM](https://user-images.githubusercontent.com/5192743/234685001-52dbab94-ee26-488e-85ea-166cdd7a94cf.png)

