### PR TITLE
Optimize whitespace in dependencies widget

### DIFF
--- a/src/features/dependencies/components/Dependencies.tsx
+++ b/src/features/dependencies/components/Dependencies.tsx
@@ -82,12 +82,7 @@ export const Dependencies = ({
           {dependencies.length ? (
             <>
               {dependencies.map((dependency, index) => (
-                <Box
-                  key={dependency.id}
-                  sx={{
-                    marginBottom: index === listLength - 1 ? "0px" : "20px"
-                  }}
-                >
+                <Box key={dependency.id}>
                   <DependenciesItem
                     mode={mode}
                     dependency={dependency}


### PR DESCRIPTION
Fixes #242 

This PR,

- [x] Removes bottom margin rule from the dependencies widget

## Screenshots

**Before**
<img width="412" alt="image" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/f906a05e-13df-4fa5-b733-d9d13400c673">

**After**
<img width="378" alt="image" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/96415886-bf72-4779-8b2c-7d237e709832">

## Questions

- Do we want to increase the height of the widget?  That would mean we need to change the surrounding areas to use `flex` for it to be properly rendered. In case we want to go that way, I would suggest to do it in a follow up PR.
