### PR TITLE
Fix size of requested packages widget

### DIFF
--- a/src/features/requestedPackages/components/RequestedPackageList.tsx
+++ b/src/features/requestedPackages/components/RequestedPackageList.tsx
@@ -28,7 +28,10 @@ export const RequestedPackageList = ({
 
   return (
     <Accordion
-      sx={{ width: 420, boxShadow: "none" }}
+      sx={{
+        maxWidth: 420,
+        boxShadow: "none"
+      }}
       disableGutters
       defaultExpanded
     >


### PR DESCRIPTION
Fixes #232 

This PR,

- [x] Fixes the css rule for the width of the requested packages widget

As this change affects the UI, this are the screenshots on how it changes.

**Before**
<img width="420" alt="image" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/cbb36ee2-3719-4c63-8946-77821633527a">

**After**
<img width="385" alt="image" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/8b8552c8-6b12-4ffd-8831-7570f16fd5ec">

In case the windows is too small to show all the elements, a horizontal scrollbar appears

<img width="277" alt="image" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/81fc7f0d-3968-49d7-a19f-d061ba6ced6a">
