### PR TITLE
Remove square icon in dependencies and channel widgets

### DIFF
--- a/src/features/channels/components/Channel.tsx
+++ b/src/features/channels/components/Channel.tsx
@@ -1,8 +1,6 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { getIconForStyleType } from "../../../utils/helpers";
-import { SquareIconAlt } from "../../../components";
 
 interface IChannelProps {
   /**
@@ -12,14 +10,8 @@ interface IChannelProps {
 }
 
 export const Channel = ({ channelName }: IChannelProps) => {
-  const icon = getIconForStyleType(
-    <></>,
-    <SquareIconAlt style={{ marginRight: "8px" }} />
-  );
-
   return (
     <Box className="box" sx={{ display: "flex", alignItems: "center" }}>
-      {icon}
       <Typography
         className="typography"
         sx={{ color: "#333", fontSize: "13px" }}

--- a/src/features/dependencies/components/DependenciesItem.tsx
+++ b/src/features/dependencies/components/DependenciesItem.tsx
@@ -4,8 +4,7 @@ import Typography from "@mui/material/Typography";
 import { Dependency } from "../../../common/models";
 import Tooltip from "@mui/material/Tooltip";
 import { StyledIconButton } from "../../../styles";
-import { getIconForStyleType } from "../../../utils/helpers";
-import { SquareIconAlt, UploadIcon } from "../../../components";
+import { UploadIcon } from "../../../components";
 
 interface IDependenciesItemProps {
   /**
@@ -26,15 +25,9 @@ const BaseDependenciesItem = ({
   const { name, version } = dependency;
   const isEditMode = mode === "edit";
 
-  const icon = getIconForStyleType(
-    <></>,
-    <SquareIconAlt style={{ marginRight: "8px" }} />
-  );
-
   return (
     <Box sx={{ display: "flex", alignItems: "center" }}>
       <Box sx={{ display: "flex", alignItems: "center", width: "300px" }}>
-        {icon}
         <Typography sx={{ fontSize: "13px", color: "#333" }}>{name}</Typography>
       </Box>
       <Typography


### PR DESCRIPTION
Fixes #266.
<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed descrition for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
<!-- What is the purpose of this pull request? -->

This pull request:

- [x] Removes the square icon in the dependencies widget
- [x] Removes the square icon in the dependencies widget
- [x] Make sure the look & feel doesn't change between themes

### Before

**grayscale**

![image](https://github.com/conda-incubator/conda-store-ui/assets/20992645/17d55f89-9c8f-4f19-bcd4-1ef53d4ecc5b)

**green-accent**

![image](https://github.com/conda-incubator/conda-store-ui/assets/20992645/0a7bb8d2-277a-4c02-861f-dbc8802bb00d)

### After

**grayscale**

<img width="911" alt="grayscale" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/fee30884-3d23-49f4-adbe-4c14132a3abb">

**green-accent**

<img width="901" alt="greennuevo" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/9205f76d-3c12-42a3-ba37-af91991fb693">

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentaion (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

The decision was to remove the square icon given that it made it seem as a checkbox.