### PR TITLE
ENH - Improve default build selection workflow

### DIFF
--- a/src/features/environmentDetails/components/EnvironmentDetails.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetails.tsx
@@ -69,6 +69,7 @@ export const EnvironmentDetails = ({
   const [artifactType, setArtifactType] = useState<string[]>([]);
   const [showDialog, setShowDialog] = useState(false);
   const [defaultEnvIsChanged, setDefaultEnvIsChanged] = useState(false);
+  const [specificationIsChanged, setSpecificationIsChanged] = useState(false);
   const [error, setError] = useState({
     message: "",
     visible: false
@@ -100,6 +101,10 @@ export const EnvironmentDetails = ({
   const updateDescription = (description: string) => {
     setDescription(description);
     setDescriptionIsUpdated(true);
+  };
+
+  const updateSpecificationIsChanged = (isChanged: boolean) => {
+    setSpecificationIsChanged(isChanged);
   };
 
   const updateDefaultEnvironment = (isChanged: boolean) => {
@@ -273,6 +278,7 @@ export const EnvironmentDetails = ({
           currentBuildId={selectedEnvironment?.current_build_id}
           selectedBuildId={currentBuildId}
           description={description}
+          specificationIsChanged={specificationIsChanged}
           onDefaultEnvIsChanged={updateDefaultEnvironment}
           onUpdateDescription={updateDescription}
           onUpdateBuildId={updateBuild}
@@ -284,6 +290,7 @@ export const EnvironmentDetails = ({
           <SpecificationEdit
             descriptionUpdated={descriptionIsUpdated}
             defaultEnvIsChanged={defaultEnvIsChanged}
+            onSpecificationIsChanged={updateSpecificationIsChanged}
             onDefaultEnvIsChanged={updateDefaultEnvironment}
             onUpdateEnvironment={updateEnvironment}
             onShowDialogAlert={showDialog => setShowDialog(showDialog)}

--- a/src/features/environmentDetails/components/EnvironmentDetails.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetails.tsx
@@ -68,6 +68,7 @@ export const EnvironmentDetails = ({
   );
   const [artifactType, setArtifactType] = useState<string[]>([]);
   const [showDialog, setShowDialog] = useState(false);
+  const [defaultEnvIsChanged, setDefaultEnvIsChanged] = useState(false);
   const [error, setError] = useState({
     message: "",
     visible: false
@@ -99,6 +100,10 @@ export const EnvironmentDetails = ({
   const updateDescription = (description: string) => {
     setDescription(description);
     setDescriptionIsUpdated(true);
+  };
+
+  const updateDefaultEnvironment = (isChanged: boolean) => {
+    setDefaultEnvIsChanged(isChanged);
   };
 
   const loadArtifacts = async () => {
@@ -268,6 +273,7 @@ export const EnvironmentDetails = ({
           currentBuildId={selectedEnvironment?.current_build_id}
           selectedBuildId={currentBuildId}
           description={description}
+          onDefaultEnvIsChanged={updateDefaultEnvironment}
           onUpdateDescription={updateDescription}
           onUpdateBuildId={updateBuild}
         />
@@ -277,6 +283,8 @@ export const EnvironmentDetails = ({
         {mode === "edit" && (
           <SpecificationEdit
             descriptionUpdated={descriptionIsUpdated}
+            defaultEnvIsChanged={defaultEnvIsChanged}
+            onDefaultEnvIsChanged={updateDefaultEnvironment}
             onUpdateEnvironment={updateEnvironment}
             onShowDialogAlert={showDialog => setShowDialog(showDialog)}
           />

--- a/src/features/environmentDetails/components/EnvironmentDetails.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetails.tsx
@@ -68,7 +68,7 @@ export const EnvironmentDetails = ({
   );
   const [artifactType, setArtifactType] = useState<string[]>([]);
   const [showDialog, setShowDialog] = useState(false);
-  const [defaultEnvIsChanged, setDefaultEnvIsChanged] = useState(false);
+  const [defaultEnvVersIsChanged, setDefaultEnvVersIsChanged] = useState(false);
   const [specificationIsChanged, setSpecificationIsChanged] = useState(false);
   const [error, setError] = useState({
     message: "",
@@ -107,8 +107,8 @@ export const EnvironmentDetails = ({
     setSpecificationIsChanged(isChanged);
   };
 
-  const updateDefaultEnvironment = (isChanged: boolean) => {
-    setDefaultEnvIsChanged(isChanged);
+  const updateDefaultEnvironmentVersion = (isChanged: boolean) => {
+    setDefaultEnvVersIsChanged(isChanged);
   };
 
   const loadArtifacts = async () => {
@@ -279,7 +279,7 @@ export const EnvironmentDetails = ({
           selectedBuildId={currentBuildId}
           description={description}
           specificationIsChanged={specificationIsChanged}
-          onDefaultEnvIsChanged={updateDefaultEnvironment}
+          onDefaultEnvIsChanged={updateDefaultEnvironmentVersion}
           onUpdateDescription={updateDescription}
           onUpdateBuildId={updateBuild}
         />
@@ -289,9 +289,9 @@ export const EnvironmentDetails = ({
         {mode === "edit" && (
           <SpecificationEdit
             descriptionUpdated={descriptionIsUpdated}
-            defaultEnvIsChanged={defaultEnvIsChanged}
+            defaultEnvVersIsChanged={defaultEnvVersIsChanged}
             onSpecificationIsChanged={updateSpecificationIsChanged}
-            onDefaultEnvIsChanged={updateDefaultEnvironment}
+            onDefaultEnvIsChanged={updateDefaultEnvironmentVersion}
             onUpdateEnvironment={updateEnvironment}
             onShowDialogAlert={showDialog => setShowDialog(showDialog)}
           />

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -26,11 +26,15 @@ import { StyledButtonPrimary } from "../../../../styles";
 import { CondaSpecificationPip } from "../../../../common/models";
 interface ISpecificationEdit {
   descriptionUpdated: boolean;
+  defaultEnvIsChanged: boolean;
+  onDefaultEnvIsChanged: (defaultEnvIsChanged: boolean) => void;
   onUpdateEnvironment: (specification: any) => void;
   onShowDialogAlert: (showDialog: boolean) => void;
 }
 export const SpecificationEdit = ({
   descriptionUpdated,
+  defaultEnvIsChanged,
+  onDefaultEnvIsChanged,
   onUpdateEnvironment,
   onShowDialogAlert
 }: ISpecificationEdit) => {
@@ -64,7 +68,12 @@ export const SpecificationEdit = ({
 
   const onUpdateChannels = useCallback((channels: string[]) => {
     dispatch(updateChannels(channels));
+    onDefaultEnvIsChanged(false);
   }, []);
+
+  const onUpdateDefaultEnvironment = (isChanged: boolean) => {
+    onDefaultEnvIsChanged(isChanged);
+  };
 
   const onUpdateEditor = debounce(
     ({
@@ -90,6 +99,7 @@ export const SpecificationEdit = ({
 
       if (isDifferentChannels || isDifferentPackages) {
         setEnvIsUpdated(true);
+        onUpdateDefaultEnvironment(false);
       }
 
       setCode(code);
@@ -133,7 +143,9 @@ export const SpecificationEdit = ({
     const isDifferentPackages =
       JSON.stringify(requestedPackages) !== stringifiedInitialPackages;
 
-    if (isDifferentChannels || isDifferentPackages) {
+    if (defaultEnvIsChanged) {
+      setEnvIsUpdated(false);
+    } else if (isDifferentChannels || isDifferentPackages) {
       setEnvIsUpdated(true);
     }
   }, [channels, requestedPackages, descriptionUpdated]);
@@ -153,7 +165,10 @@ export const SpecificationEdit = ({
         ) : (
           <>
             <Box sx={{ marginBottom: "30px" }}>
-              <RequestedPackagesEdit packageList={requestedPackages} />
+              <RequestedPackagesEdit
+                packageList={requestedPackages}
+                onDefaultEnvIsChanged={onUpdateDefaultEnvironment}
+              />
             </Box>
             <Box sx={{ marginBottom: "30px" }}>
               <Dependencies

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -27,6 +27,7 @@ import { CondaSpecificationPip } from "../../../../common/models";
 interface ISpecificationEdit {
   descriptionUpdated: boolean;
   defaultEnvIsChanged: boolean;
+  onSpecificationIsChanged: (specificationIsChanged: boolean) => void;
   onDefaultEnvIsChanged: (defaultEnvIsChanged: boolean) => void;
   onUpdateEnvironment: (specification: any) => void;
   onShowDialogAlert: (showDialog: boolean) => void;
@@ -34,6 +35,7 @@ interface ISpecificationEdit {
 export const SpecificationEdit = ({
   descriptionUpdated,
   defaultEnvIsChanged,
+  onSpecificationIsChanged,
   onDefaultEnvIsChanged,
   onUpdateEnvironment,
   onShowDialogAlert
@@ -73,6 +75,7 @@ export const SpecificationEdit = ({
 
   const onUpdateDefaultEnvironment = (isChanged: boolean) => {
     onDefaultEnvIsChanged(isChanged);
+    onSpecificationIsChanged(!isChanged);
   };
 
   const onUpdateEditor = debounce(
@@ -100,6 +103,7 @@ export const SpecificationEdit = ({
       if (isDifferentChannels || isDifferentPackages) {
         setEnvIsUpdated(true);
         onUpdateDefaultEnvironment(false);
+        onSpecificationIsChanged(true);
       }
 
       setCode(code);
@@ -128,6 +132,7 @@ export const SpecificationEdit = ({
 
   const onCancelEdition = () => {
     setEnvIsUpdated(false);
+    onSpecificationIsChanged(false);
     dispatch(modeChanged(EnvironmentDetailsModes.READ));
     dispatch(updatePackages(initialPackages.current));
     dispatch(updateChannels(initialChannels.current));

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -26,15 +26,15 @@ import { StyledButtonPrimary } from "../../../../styles";
 import { CondaSpecificationPip } from "../../../../common/models";
 interface ISpecificationEdit {
   descriptionUpdated: boolean;
-  defaultEnvIsChanged: boolean;
+  defaultEnvVersIsChanged: boolean;
   onSpecificationIsChanged: (specificationIsChanged: boolean) => void;
-  onDefaultEnvIsChanged: (defaultEnvIsChanged: boolean) => void;
+  onDefaultEnvIsChanged: (defaultEnvVersIsChanged: boolean) => void;
   onUpdateEnvironment: (specification: any) => void;
   onShowDialogAlert: (showDialog: boolean) => void;
 }
 export const SpecificationEdit = ({
   descriptionUpdated,
-  defaultEnvIsChanged,
+  defaultEnvVersIsChanged,
   onSpecificationIsChanged,
   onDefaultEnvIsChanged,
   onUpdateEnvironment,
@@ -148,7 +148,7 @@ export const SpecificationEdit = ({
     const isDifferentPackages =
       JSON.stringify(requestedPackages) !== stringifiedInitialPackages;
 
-    if (defaultEnvIsChanged) {
+    if (defaultEnvVersIsChanged) {
       setEnvIsUpdated(false);
     } else if (isDifferentChannels || isDifferentPackages) {
       setEnvIsUpdated(true);

--- a/src/features/metadata/components/EnvBuilds.tsx
+++ b/src/features/metadata/components/EnvBuilds.tsx
@@ -29,7 +29,7 @@ export const EnvBuilds = ({
           paddingBottom: "5px"
         }}
       >
-        {mode === "edit" ? "Change Default Build:" : "Builds:"}
+        {mode === "edit" ? "Change active environment version:" : "Builds:"}
       </StyledMetadataItem>
       {currentBuild && (
         <>

--- a/src/features/metadata/components/EnvBuilds.tsx
+++ b/src/features/metadata/components/EnvBuilds.tsx
@@ -9,12 +9,14 @@ interface IData {
   currentBuildId: number;
   selectedBuildId: number;
   builds: IBuild[];
+  mode: "create" | "read-only" | "edit";
 }
 
 export const EnvBuilds = ({
   currentBuildId,
   selectedBuildId,
-  builds
+  builds,
+  mode
 }: IData) => {
   const envBuilds = builds.length ? buildMapper(builds, currentBuildId) : [];
   const currentBuild = envBuilds.find(build => build.id === selectedBuildId);
@@ -27,7 +29,7 @@ export const EnvBuilds = ({
           paddingBottom: "5px"
         }}
       >
-        Builds:
+        {mode === "edit" ? "Change Default Build:" : "Builds:"}
       </StyledMetadataItem>
       {currentBuild && (
         <>

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -18,6 +18,8 @@ interface IEnvMetadataProps {
   mode: "create" | "read-only" | "edit";
   currentBuildId?: number | undefined;
   selectedBuildId?: number;
+  defaultEnvIsChanged?: boolean;
+  specificationIsChanged?: boolean;
   onDefaultEnvIsChanged?: (defaultEnvIsChanged: boolean) => void;
   onUpdateDescription: (description: string) => void;
   onUpdateBuildId: (buildId: number) => void;
@@ -28,6 +30,7 @@ export const EnvMetadata = ({
   description = "",
   currentBuildId,
   selectedBuildId,
+  specificationIsChanged,
   onDefaultEnvIsChanged,
   onUpdateDescription,
   onUpdateBuildId
@@ -40,6 +43,14 @@ export const EnvMetadata = ({
     onUpdateBuildId(newCurrentBuild);
     if (onDefaultEnvIsChanged) {
       onDefaultEnvIsChanged(true);
+    }
+  };
+
+  const specificationDidChange = () => {
+    if (specificationIsChanged) {
+      return specificationIsChanged;
+    } else {
+      return false;
     }
   };
 
@@ -77,8 +88,9 @@ export const EnvMetadata = ({
               variant="contained"
               onClick={() => defaultEnvironmentChanged(newCurrentBuild)}
               isalttype="true"
+              disabled={specificationDidChange()}
             >
-              Update Environment Build
+              Change environment version
             </StyledButtonPrimary>
           )}
       </div>

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -56,6 +56,7 @@ export const EnvMetadata = ({
                 currentBuildId={currentBuildId}
                 selectedBuildId={selectedBuildId}
                 builds={builds}
+                mode={mode}
               />
             </div>
           )}

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -18,6 +18,7 @@ interface IEnvMetadataProps {
   mode: "create" | "read-only" | "edit";
   currentBuildId?: number | undefined;
   selectedBuildId?: number;
+  onDefaultEnvIsChanged?: (defaultEnvIsChanged: boolean) => void;
   onUpdateDescription: (description: string) => void;
   onUpdateBuildId: (buildId: number) => void;
 }
@@ -27,12 +28,20 @@ export const EnvMetadata = ({
   description = "",
   currentBuildId,
   selectedBuildId,
+  onDefaultEnvIsChanged,
   onUpdateDescription,
   onUpdateBuildId
 }: IEnvMetadataProps) => {
   const { builds, newCurrentBuild } = useAppSelector(
     state => state.enviroments
   );
+
+  const defaultEnvironmentChanged = (newCurrentBuild: number) => {
+    onUpdateBuildId(newCurrentBuild);
+    if (onDefaultEnvIsChanged) {
+      onDefaultEnvIsChanged(true);
+    }
+  };
 
   return (
     <BlockContainer title="Environment Metadata">
@@ -66,7 +75,7 @@ export const EnvMetadata = ({
           currentBuildId !== newCurrentBuild && (
             <StyledButtonPrimary
               variant="contained"
-              onClick={() => onUpdateBuildId(newCurrentBuild)}
+              onClick={() => defaultEnvironmentChanged(newCurrentBuild)}
               isalttype="true"
             >
               Update Environment Build

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -18,9 +18,9 @@ interface IEnvMetadataProps {
   mode: "create" | "read-only" | "edit";
   currentBuildId?: number | undefined;
   selectedBuildId?: number;
-  defaultEnvIsChanged?: boolean;
+  defaultEnvVersIsChanged?: boolean;
   specificationIsChanged?: boolean;
-  onDefaultEnvIsChanged?: (defaultEnvIsChanged: boolean) => void;
+  onDefaultEnvIsChanged?: (defaultEnvVersIsChanged: boolean) => void;
   onUpdateDescription: (description: string) => void;
   onUpdateBuildId: (buildId: number) => void;
 }

--- a/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
@@ -27,10 +27,12 @@ export interface IRequestedPackagesEditProps {
    * @param packageList list of packages that we get from the API
    */
   packageList: (string | CondaSpecificationPip)[];
+  onDefaultEnvIsChanged?: (isChanged: boolean) => void;
 }
 
 export const RequestedPackagesEdit = ({
-  packageList
+  packageList,
+  onDefaultEnvIsChanged
 }: IRequestedPackagesEditProps) => {
   const dispatch = useAppDispatch();
   const [isAdding, setIsAdding] = useState(false);
@@ -38,6 +40,15 @@ export const RequestedPackagesEdit = ({
 
   const handleSubmit = (packageName: string) => {
     dispatch(packageAdded(packageName));
+    if (onDefaultEnvIsChanged) {
+      onUpdateDefaultEnvironment(false);
+    }
+  };
+
+  const onUpdateDefaultEnvironment = (isChanged: boolean) => {
+    if (onDefaultEnvIsChanged) {
+      onDefaultEnvIsChanged(isChanged);
+    }
   };
 
   const filteredPackageList = useMemo(
@@ -104,6 +115,7 @@ export const RequestedPackagesEdit = ({
               <RequestedPackagesTableRow
                 key={requestedPackage}
                 requestedPackage={requestedPackage}
+                onDefaultEnvIsChanged={onUpdateDefaultEnvironment}
               />
             ))}
           </TableBody>

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -20,10 +20,12 @@ interface IRequestedPackagesTableRowProps {
    * @param requestedPackage requested package
    */
   requestedPackage: string;
+  onDefaultEnvIsChanged?: (isChanged: boolean) => void;
 }
 
 const BaseRequestedPackagesTableRow = ({
-  requestedPackage
+  requestedPackage,
+  onDefaultEnvIsChanged
 }: IRequestedPackagesTableRowProps) => {
   const dispatch = useAppDispatch();
   const { versionsWithoutConstraints, versionsWithConstraints } =
@@ -35,6 +37,12 @@ const BaseRequestedPackagesTableRow = ({
   if (constraint === "latest") {
     version = versionsWithoutConstraints[name];
   }
+
+  const onUpdateDefaultEnvironment = (isChanged: boolean) => {
+    if (onDefaultEnvIsChanged) {
+      onDefaultEnvIsChanged(isChanged);
+    }
+  };
 
   const updateVersion = (value: string) => {
     let pkgConstraint = constraint === "latest" ? ">=" : constraint;
@@ -48,6 +56,7 @@ const BaseRequestedPackagesTableRow = ({
     dispatch(
       packageUpdated({ currentPackage: requestedPackage, updatedPackage })
     );
+    onUpdateDefaultEnvironment(false);
   };
 
   const updateConstraint = (value: string) => {
@@ -56,9 +65,13 @@ const BaseRequestedPackagesTableRow = ({
     dispatch(
       packageUpdated({ currentPackage: requestedPackage, updatedPackage })
     );
+    onUpdateDefaultEnvironment(false);
   };
 
-  const handleRemove = () => dispatch(packageRemoved(requestedPackage));
+  const handleRemove = () => {
+    dispatch(packageRemoved(requestedPackage));
+    onUpdateDefaultEnvironment(false);
+  };
 
   return (
     <TableRow>


### PR DESCRIPTION
Part of #269.
<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed descrition for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
<!-- What is the purpose of this pull request? -->

This pull request:

- Changes the label in edit mode so that the user understands that changing an option in the combobox will change the default build

**Before**
<img width="577" alt="image" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/365c8640-7f84-4eed-9ce9-889426518c67">

**Now**
<img width="951" alt="image" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/408c3e53-23c2-4baf-87cd-abc035db2d19">

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentaion (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

Please note that the screenshots were taken with different themes