### PR TITLE
Improve default yaml environment template

### DIFF
--- a/src/features/artifacts/components/ArtifactList.tsx
+++ b/src/features/artifacts/components/ArtifactList.tsx
@@ -19,7 +19,6 @@ export const ArtifactList = ({ artifacts }: IArtifactsProps) => {
 
   // Groups all the artifacts that start with "Show" at the beginning - this is to ensure consistency across display and naming
   const order = (artifact_list: Artifact[]) => {
-    console.log(artifact_list);
     const ordered_list = [];
     for (let i = 0; i < artifact_list.length; i++) {
       const item = artifact_list[i];

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -69,6 +69,13 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
     setShow(value);
   };
 
+  const formatCode = (channels: string[], dependencies: string[]) => {
+    if (channels.length === 0 && dependencies.length === 0) {
+      return "channels:\n  -\ndependencies:\n  -";
+    }
+    return stringify({ channels, dependencies: dependencies });
+  };
+
   const handleSubmit = () => {
     const code = show
       ? editorContent
@@ -92,10 +99,7 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
       <Box>
         {show ? (
           <CodeEditor
-            code={stringify({
-              channels,
-              dependencies: requestedPackages
-            })}
+            code={formatCode(channels, requestedPackages)}
             onChangeEditor={onUpdateEditor}
           />
         ) : (


### PR DESCRIPTION
Fixes #264.
<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed descrition for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
<!-- What is the purpose of this pull request? -->

This pull request:

- Improves the default yaml environment template
- Removes an unnecessary console.log that was merged in a previous PR

**Before**
![image](https://github.com/conda-incubator/conda-store-ui/assets/20992645/024d8898-74ce-4cf0-971c-8ab5d9daf6b7)

**Now**
<img width="754" alt="Captura de pantalla 2023-08-31 a la(s) 10 03 28 a m" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/996d96b5-dc61-4990-861c-a3462c124f9e">

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentaion (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
