### PR TITLE
Disable ability to edit locked environments

### DIFF
--- a/src/features/environmentDetails/components/EnvironmentDetailsHeader.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetailsHeader.tsx
@@ -44,8 +44,7 @@ export const EnvironmentDetailsHeader = ({
           </Typography>
           {mode === EnvironmentDetailsModes.READ && (
             <StyledButtonPrimary
-              // TODO: Add this prop when the toggle button (YAML view) feature is added to the read-only view. #213
-              // disabled={!showEditButton}
+              disabled={!showEditButton}
               onClick={() =>
                 dispatch(modeChanged(EnvironmentDetailsModes.EDIT))
               }


### PR DESCRIPTION
Fixes #203.
<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
<!-- What is the purpose of this pull request? -->

This pull request:

- Enable `showEditButton` props to disable the ability to edit locked environments

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

Now the edit button is disabled if the environment is locked,

<img width="745" alt="image" src="https://github.com/conda-incubator/conda-store-ui/assets/20992645/096618a8-48c5-40ce-82e0-d783d26f1f76">
