### PR TITLE
MAINT - Update release workflow - configure node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ jobs:
       - name: "Checkout repository 🛎"
         uses: actions/checkout@v4
 
+      # Setup .npmrc file to publish to npm
+      - name: "Set up Node.js 🧶"
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+
       - name: "Install dependencies 📦"
         run: yarn
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,7 @@
 6. If the dry run looks good, publish to npmjs:
 
    ```bash
-   npm publish --access public
+   npm publish --verbose --access public conda-store-ui.tgz
    ```
 
 7. Ensure that whatever code you published is checked into git, then tag and push the commit and tag


### PR DESCRIPTION
## Description
<!-- What is the purpose of this pull request? -->
While the current workflow works in the sense of making a release to npm - it throws an error as there is no `.npmrc` file present in the runner. 

This PR ensures node is correctly set up and the file is created.
