### PR TITLE
MAINT -  Bump nodejs version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: Build conda-store-ui
 on:
   pull_request:
-    branches: 
-      - '*'
+    branches:
+      - "*"
   push:
-    branches: 
+    branches:
       - main
 
   workflow_call:
@@ -16,15 +16,15 @@ jobs:
     steps:
       - name: "Checkout repository 🛎"
         uses: actions/checkout@v4
-      
+
       - name: "Set up Node.js 🧶"
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: 18
 
       - name: "Install dependencies 📦"
         run: yarn
-  
+
       - name: "Lint code 🔍"
         run: yarn eslint:check
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: "Build application artifacts 🏗"
         run: yarn run webpack bundle
-      
+
       - name: "Upload artifacts 📤"
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: "Set up Node.js 🧶"
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: 18
           registry-url: "https://registry.npmjs.org"
 
       - name: "Install dependencies 📦"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
           pytest --video on --output test-results --screenshots true test/playwright/test_ux.py
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: playwright-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           CONDA_SOLVER: libmamba
         with:
-          activate-environment: dev-env
+          activate-environment: cs-ui-dev-env
           environment-file: environment_dev.yml
           auto-activate-base: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ env:
   REACT_APP_API_URL: http://localhost:8080/conda-store/
   REACT_APP_AUTH_METHOD: cookie
   REACT_APP_LOGIN_PAGE_URL: http://localhost:8080/conda-store/login?next=
-  REACT_APP_AUTH_TOKEN: 
+  REACT_APP_AUTH_TOKEN:
   REACT_APP_STYLE_TYPE: green-accent
   REACT_APP_CONTEXT: webapp
   REACT_APP_SHOW_AUTH_BUTTON: true
-  REACT_APP_LOGOUT_PAGE_URL: http://localhost:8080/conda-store/logout?next=/ 
+  REACT_APP_LOGOUT_PAGE_URL: http://localhost:8080/conda-store/logout?next=/
   YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
 on:
@@ -24,7 +24,7 @@ on:
 
 jobs:
   test-conda-store-ui:
-    name: 'unit-test conda-store-ui'
+    name: "unit-test conda-store-ui"
     strategy:
       matrix:
         # cannot run on windows due to needing fake-chroot for conda-docker
@@ -35,31 +35,30 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - name: 'Checkout Repository'
-        uses: actions/checkout@master
+      - name: "Checkout repository 🛎"
+        uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: "Set up Python"
         uses: conda-incubator/setup-miniconda@v2
-        env: 
+        env:
           CONDA_SOLVER: libmamba
         with:
-          activate-environment: test-env
+          activate-environment: dev-env
           environment-file: environment_dev.yml
           auto-activate-base: false
 
-      - name: Install Dependencies
+      - name: "Install Dependencies"
         run: |
           sudo apt install wait-for-it -y
 
-      - name: Deploy conda-store-server docker container
+      - name: "Deploy conda-store-server docker container"
         run: |
           docker-compose -f docker-compose-dev.yml up -d --build
           docker ps
 
           wait-for-it localhost:8080 # conda-store-server
 
-
-      - name: Deploy webpack dev server
+      - name: "Deploy webpack dev server"
         shell: bash -el {0}
         run: |
           conda list
@@ -69,7 +68,7 @@ jobs:
           yarn run start &
           pytest --video on --output test-results --screenshots true test/playwright/test_ux.py
 
-      - name: Upload artifacts
+      - name: "Upload artifacts"
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 18.18-alpine3.18
+FROM node:18.18-alpine3.18
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.16-alpine3.18
+FROM 18.18-alpine3.18
 
 WORKDIR /usr/src/app
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ---
 
-| Information | Links |
-| :---------- | :-----|
-|   Project   | [![License](https://img.shields.io/badge/License-BSD%203--Clause-gray.svg?&colorB=298642&style=flat.svg)](https://opensource.org/licenses/BSD-3-Clause) [![conda-store documentation](https://img.shields.io/badge/conda--store-documentation%20📖-gray.svg?&colorB=298642&style=flat.svg)][conda-store-docs] [![conda-store-ui documentation](https://img.shields.io/badge/conda--store--UI-documentation%20📖-gray.svg?&colorB=298642&style=flat.svg)][conda-store-ui-docs] |
-| Wofklows |  ![GitHub Workflow Status - Build](https://img.shields.io/github/actions/workflow/status/conda-incubator/conda-store-ui/build.yml?label=Build&logo=GitHub) ![GitHub Workflow Status (with event) - Release](https://img.shields.io/github/actions/workflow/status/conda-incubator/conda-store-ui/release.yml?event=push&label=Release&logo=GitHub) ![GitHub Workflow Status - GitHub pages](https://img.shields.io/github/actions/workflow/status/conda-incubator/conda-store-ui/pages.yml?label=Docs&logo=GitHub) |
-| Releases | ![GitHub release (the latest by date)](https://img.shields.io/github/v/release/conda-incubator/conda-store-ui?logo=Github) ![npm release version](https://img.shields.io/npm/v/@conda-store/conda-store-ui?label=release&logo=npm) |
+| Information | Links                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| :---------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Project     | [![License](https://img.shields.io/badge/License-BSD%203--Clause-gray.svg?&colorB=298642&style=flat.svg)](https://opensource.org/licenses/BSD-3-Clause) [![conda-store documentation](https://img.shields.io/badge/conda--store-documentation%20📖-gray.svg?&colorB=298642&style=flat.svg)][conda-store-docs] [![conda-store-ui documentation](https://img.shields.io/badge/conda--store--UI-documentation%20📖-gray.svg?&colorB=298642&style=flat.svg)][conda-store-ui-docs]                                     |
+| Wofklows    | ![GitHub Workflow Status - Build](https://img.shields.io/github/actions/workflow/status/conda-incubator/conda-store-ui/build.yml?label=Build&logo=GitHub) ![GitHub Workflow Status (with event) - Release](https://img.shields.io/github/actions/workflow/status/conda-incubator/conda-store-ui/release.yml?event=push&label=Release&logo=GitHub) ![GitHub Workflow Status - GitHub pages](https://img.shields.io/github/actions/workflow/status/conda-incubator/conda-store-ui/pages.yml?label=Docs&logo=GitHub) |
+| Releases    | ![GitHub release (the latest by date)](https://img.shields.io/github/v/release/conda-incubator/conda-store-ui?logo=Github) ![npm release version](https://img.shields.io/npm/v/@conda-store/conda-store-ui?label=release&logo=npm)                                                                                                                                                                                                                                                                                |
 
 ---
 
@@ -65,18 +65,20 @@ To get started:
    yarn run start
    ```
 
-When compiling the application for development you will need to set a number of environment variables. Refer to the [Configuration documentation](https://conda-incubator.github.io/conda-store-ui/?path=/docs/docs-configuration--page) for more information.
+When compiling the application for development you will need to set several environment variables.
+Refer to the [Configuration documentation](https://conda-incubator.github.io/conda-store-ui/?path=/docs/docs-configuration--page) for more information.
 
 ### Making a release
 
 To create a new version of this package, follow these steps:
 
 <!-- TODO: need to link to CalVer/release docs -->
+
 1. Bump the version number in `package.json` (we use CalVer: `YYYY.MM.releaseNumber` starting with `releaseNumber=1`)
 2. [Start a new GitHub release](https://github.com/conda-incubator/conda-store-ui/releases/new)
-    - Call the release the current version, e.g. `2023.9.1`
-    - In the **`Choose a Tag:`** dropdown, type in the release name (e.g., `2023.9.1`) and click "Create new tag"
-    - Add the release notes in the text field [^github-activity]
+   - Call the release the current version, e.g. `2023.9.1`
+   - In the **`Choose a Tag:`** dropdown, type in the release name (e.g., `2023.9.1`) and click "Create new tag"
+   - Add the release notes in the text field [^github-activity]
 3. Confirm that the release completed successfully by checking the [GitHub Actions page](https://github.com/conda-incubator/conda-store-ui/actions). Once completed, a new release will be available at [npm - @conda-store/conda-store-ui](https://libraries.io/npm/@conda-store%2Fconda-store-ui)
 
 [^github-activity]: If you wish, use [`github-activity` to generate a Changelog](https://github.com/choldgraf/github-activity), e.g. `github-activity conda-incubator/conda-store-ui --since 2023.9.1 --until 2023.10.1 --auth <GH personal access token>`

--- a/README.md
+++ b/README.md
@@ -44,15 +44,17 @@ To get started:
    docker-compose -f docker-compose-dev.yml up --build
    ```
 
-2. Install yarn and NodeJS:
+2. Install yarn and NodeJS with conda:
 
-   > **Note**
+   > [!NOTE]
    > Skip this if you are planning to use a local installation of yarn and NodeJS
 
    ```bash
-   conda create --name conda-store-ui
-   conda activate conda-store-ui
-   conda install -c conda-forge yarn nodejs==16.14.2
+   conda env create -f environment_dev.yml
+
+   # activate the newly created environment
+   conda activate cs-ui-dev-env
+
    ```
 
 3. Finally, start the conda-store-ui application:
@@ -65,8 +67,11 @@ To get started:
    yarn run start
    ```
 
-When compiling the application for development you will need to set several environment variables.
-Refer to the [Configuration documentation](https://conda-incubator.github.io/conda-store-ui/?path=/docs/docs-configuration--page) for more information.
+   once completed, you should be able to access the application at [http://localhost:8000/](http://localhost:8000/)
+
+> [!IMPORTANT]
+> When compiling the application for development you will need to set several environment variables.
+> Refer to the [Configuration documentation](https://conda-incubator.github.io/conda-store-ui/?path=/docs/docs-configuration--page) for more information.
 
 ### Making a release
 

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,7 +1,7 @@
 # Environment for developing the conda-store-ui and for running
 # playwright tests
 
-name: dev-env
+name: cs-ui-dev-env
 channels:
   - conda-forge
 dependencies:

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,14 +1,15 @@
-# Environment for developing the conda-store-ui and for running 
+# Environment for developing the conda-store-ui and for running
 # playwright tests
 
-name: test-env
+name: dev-env
 channels:
-- conda-forge
+  - conda-forge
 dependencies:
-- python=3.10
-- yarn
-- nodejs==16.14.2
-- pytest
-- pip:
-  - playwright
-  - pytest-playwright
+  - python=3.10
+  - yarn
+  - nodejs>=18.0
+  - pytest
+  - pip
+  - pip:
+      - playwright
+      - pytest-playwright

--- a/package.json
+++ b/package.json
@@ -134,5 +134,8 @@
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.8.1",
     "whatwg-fetch": "^3.6.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
Closes #323

## Description
<!-- What is the purpose of this pull request? -->
I am unsure why we were pinning to `16.x` on nodejs in multiple places (there was no `engine` entry in the `package.json`, and I have been building/testing this project with node 20 with no problems.

This pull request:

- Bumps node version in GitHub workflows
- Bumps base node Docker image
- Bumps node version in `dev_environment.yml`
- Rename conda env (give a more descriptive name)
- Document use of conda env in README (related to #338 - though this needs documenting in the conda-store-ui docs too)

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
