### PR TITLE
Add default timeout

### DIFF
--- a/test/playwright/conftest.py
+++ b/test/playwright/conftest.py
@@ -2,9 +2,7 @@ import pytest
 
 from playwright.sync_api import expect
 
-DEFAULT_TIMEOUT = 30_000  # time in ms
 
-expect.set_options(timeout=DEFAULT_TIMEOUT)
 
 def pytest_addoption(parser):
     parser.addoption("--screenshots", action="store", default="false")

--- a/test/playwright/conftest.py
+++ b/test/playwright/conftest.py
@@ -1,5 +1,10 @@
 import pytest
 
+from playwright.sync_api import expect
+
+DEFAULT_TIMEOUT = 30_000  # time in ms
+
+expect.set_options(timeout=DEFAULT_TIMEOUT)
 
 def pytest_addoption(parser):
     parser.addoption("--screenshots", action="store", default="false")

--- a/test/playwright/test_ux.py
+++ b/test/playwright/test_ux.py
@@ -177,7 +177,7 @@ def _existing_environment_interactions(page, env_name, time_to_build_env=3*60*10
     completed.wait_for(state='attached', timeout=time_to_build_env)
 
     # ensure the namespace is expanded
-    if not expect(page.get_by_role("button", name=env_name)).to_be_visible()
+    if not expect(page.get_by_role("button", name=env_name)).to_be_visible():
         # click to expand the `username` name space (but not click the +)
         page.get_by_role("button", name="username Create a new environment in the username namespace").click()
 

--- a/test/playwright/test_ux.py
+++ b/test/playwright/test_ux.py
@@ -10,6 +10,10 @@ from playwright.sync_api import Page, sync_playwright, expect
 import random
 
 
+DEFAULT_TIMEOUT = 30_000  # time in ms
+
+expect.set_options(timeout=DEFAULT_TIMEOUT)
+
 CONDA_STORE_SERVER_PORT = os.environ.get(
     "CONDA_STORE_SERVER_PORT", f"8080"
 )
@@ -176,7 +180,9 @@ def _existing_environment_interactions(page, env_name, time_to_build_env=3*60*10
     completed.wait_for(state='attached', timeout=time_to_build_env)
 
     # ensure the namespace is expanded
-    if not expect(page.get_by_role("button", name=env_name)).to_be_visible():
+    try: 
+        expect(page.get_by_role("button", name=env_name)).to_be_visible()
+    except Exception as e:
         # click to expand the `username` name space (but not click the +)
         page.get_by_role("button", name="username Create a new environment in the username namespace").click()
 

--- a/test/playwright/test_ux.py
+++ b/test/playwright/test_ux.py
@@ -166,70 +166,70 @@ def _existing_environment_interactions(page, env_name, time_to_build_env=3*60*10
     # edit existing environment throught the YAML editor
     page.get_by_role("button", name=env_name).click()
     page.get_by_role("button", name="Edit").click()
-    # page.get_by_label("Switch to YAML Editor").check()
-    # if screenshot:
-    #     page.screenshot(path="test-results/conda-store-yaml-editor.png")
-    # page.get_by_text("- rich").click()
-    # page.get_by_text("channels: - conda-forgedependencies: - rich - pip: - nothing - ipykernel").fill("channels:\n  - conda-forge\ndependencies:\n  - rich\n  - python\n  - pip:\n      - nothing\n  - ipykernel\n\n")
-    # page.get_by_role("button", name="Save").click()
-    # # wait until the status is `Completed`
-    # completed = page.get_by_text("Completed", exact=False)
-    # completed.wait_for(state='attached', timeout=time_to_build_env)
+    page.get_by_label("YAML").check()
+    if screenshot:
+        page.screenshot(path="test-results/conda-store-yaml-editor.png")
+    page.get_by_text("- rich").click()
+    page.get_by_text("channels: - conda-forgedependencies: - rich - pip: - nothing - ipykernel").fill("channels:\n  - conda-forge\ndependencies:\n  - rich\n  - python\n  - pip:\n      - nothing\n  - ipykernel\n\n")
+    page.get_by_role("button", name="Save").click()
+    # wait until the status is `Completed`
+    completed = page.get_by_text("Completed", exact=False)
+    completed.wait_for(state='attached', timeout=time_to_build_env)
 
-    # # ensure the namespace is expanded
-    # if not page.get_by_role("button", name=env_name).is_visible():
-    #     # click to expand the `username` name space (but not click the +)
-    #     page.get_by_role("button", name="username Create a new environment in the username namespace").click()
+    # ensure the namespace is expanded
+    if not page.get_by_role("button", name=env_name).is_visible():
+        # click to expand the `username` name space (but not click the +)
+        page.get_by_role("button", name="username Create a new environment in the username namespace").click()
 
-    # # edit existing environment
-    # page.get_by_role("button", name=env_name).click()
-    # page.get_by_role("button", name="Edit").click()
-    # # page.get_by_placeholder("Enter here the description of your environment").click()
-    # # change the description
-    # page.get_by_placeholder("Enter here the description of your environment").fill("new description")
-    # # change the vesion spec of an existing package
-    # page.get_by_role("row", name="ipykernel", exact=False).get_by_role("button").first.click()
-    # page.get_by_role("option", name=">=").click()
-    # # Note: purposefully not testing version constraint since there is inconsistent behavior here
+    # edit existing environment
+    page.get_by_role("button", name=env_name).click()
+    page.get_by_role("button", name="Edit").click()
+    # page.get_by_placeholder("Enter here the description of your environment").click()
+    # change the description
+    page.get_by_placeholder("Enter here the description of your environment").fill("new description")
+    # change the vesion spec of an existing package
+    page.get_by_role("row", name="ipykernel", exact=False).get_by_role("button").first.click()
+    page.get_by_role("option", name=">=").click()
+    # Note: purposefully not testing version constraint since there is inconsistent behavior here
 
-    # # add a new package
-    # page.get_by_role("button", name="+ Add Package").click()
-    # page.get_by_label("Enter package").fill("click")
-    # page.get_by_role("option", name="click", exact=True).click()
-    # # Note: purposefully not testing version constraint since there is inconsistent behavior here
+    # add a new package
+    page.get_by_role("button", name="+ Add Package").click()
+    page.get_by_label("Enter package").fill("click")
+    page.get_by_role("option", name="click", exact=True).click()
+    # Note: purposefully not testing version constraint since there is inconsistent behavior here
     
-    # # delete a package
-    # page.get_by_role("row", name="rich", exact=False).get_by_test_id("RemovePackageTest").click()
+    # delete a package
+    page.get_by_role("row", name="rich", exact=False).get_by_test_id("RemovePackageTest").click()
 
-    # # promote a package installed as dependency to specified package
-    # page.locator("#infScroll > .infinite-scroll-component__outerdiv > .infinite-scroll-component > div > div > .MuiButtonBase-root").first.click()
+    # promote a package installed as dependency to specified package
+    page.locator("#infScroll > .infinite-scroll-component__outerdiv > .infinite-scroll-component > div > div > .MuiButtonBase-root").first.click()
     
-    # # delete conda-forge channel
-    # page.get_by_test_id("DeleteIcon").click()
-    # # add conda-forge channel
-    # page.get_by_role("button", name="+ Add Channel").click()
-    # page.get_by_label("Enter channel").fill("conda-forge")
-    # page.get_by_label("Enter channel").press("Enter")
-    # # click save to start the new env build
-    # page.get_by_role("button", name="Save").click()
+    # delete conda-forge channel
+    page.get_by_test_id("DeleteIcon").click()
+    # add conda-forge channel
+    page.get_by_role("button", name="+ Add Channel").click()
+    page.get_by_label("Enter channel").fill("conda-forge")
+    page.get_by_label("Enter channel").press("Enter")
+    # click save to start the new env build
+    page.get_by_role("button", name="Save").click()
 
-    # # wait until the status is `Completed`
-    # completed = page.get_by_text("Completed", exact=False)
-    # completed.wait_for(state='attached', timeout=time_to_build_env)
+    # wait until the status is `Completed`
+    completed = page.get_by_text("Completed", exact=False)
+    completed.wait_for(state='attached', timeout=time_to_build_env)
 
 
-    # # Edit -> Cancel editing
-    # page.get_by_role("button", name=env_name).click()
-    # page.get_by_role("button", name="Edit").click()
-    # page.get_by_role("button", name="Cancel").click()
+    # Edit -> Cancel editing
+    page.get_by_role("button", name=env_name).click()
+    page.get_by_role("button", name="Edit").click()
+    page.get_by_role("button", name="Cancel").click()
 
-    # # Edit -> Delete environment
-    # page.get_by_role("button", name="Edit").click()
-    # page.get_by_text("Delete environment").click()
-    # page.get_by_role("button", name="Delete").click()
+    # Edit -> Delete environment
+    page.get_by_role("button", name="Edit").click()
+    page.get_by_text("Delete environment").click()
+    page.get_by_role("button", name="Delete").click()
 
-    # time.sleep(5)  # wait for it to render, flaky otherwise
-    # assert not page.get_by_role("button", name=env_name).is_visible()
+    time.sleep(5)  # wait for it to render, flaky otherwise
+    assert not page.get_by_role("button", name=env_name).is_visible()
 
 
 

--- a/test/playwright/test_ux.py
+++ b/test/playwright/test_ux.py
@@ -228,7 +228,6 @@ def _existing_environment_interactions(page, env_name, time_to_build_env=3*60*10
     page.get_by_text("Delete environment").click()
     page.get_by_role("button", name="Delete").click()
 
-    time.sleep(5)  # wait for it to render, flaky otherwise
     assert not page.get_by_role("button", name=env_name).is_visible()
 
 

--- a/test/playwright/test_ux.py
+++ b/test/playwright/test_ux.py
@@ -6,8 +6,7 @@ import requests
 import time
 
 import pytest
-from playwright.sync_api import Page
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import Page, sync_playwright, expect
 import random
 
 

--- a/test/playwright/test_ux.py
+++ b/test/playwright/test_ux.py
@@ -119,11 +119,11 @@ def _create_new_environment(page, screenshot=False):
     # click on the Active environment on the dropdown menu item (which is currently building)
     page.get_by_role("option", name=" - Active", exact=False).click()
     # ensure that the environment is building
-    assert page.get_by_text("Building").is_visible()
+    expect(page.get_by_text("Building")).to_be_visible()
     # wait until the status is `Completed`
     completed = page.get_by_text("Completed", exact=False)
     completed.wait_for(state='attached', timeout=time_to_build_env)
-    assert completed.is_visible()
+    expect(completed).to_be_visible()
 
     return new_env_name
 
@@ -177,7 +177,7 @@ def _existing_environment_interactions(page, env_name, time_to_build_env=3*60*10
     completed.wait_for(state='attached', timeout=time_to_build_env)
 
     # ensure the namespace is expanded
-    if not page.get_by_role("button", name=env_name).is_visible():
+    if not expect(page.get_by_role("button", name=env_name)).to_be_visible()
         # click to expand the `username` name space (but not click the +)
         page.get_by_role("button", name="username Create a new environment in the username namespace").click()
 
@@ -217,7 +217,6 @@ def _existing_environment_interactions(page, env_name, time_to_build_env=3*60*10
     completed = page.get_by_text("Completed", exact=False)
     completed.wait_for(state='attached', timeout=time_to_build_env)
 
-
     # Edit -> Cancel editing
     page.get_by_role("button", name=env_name).click()
     page.get_by_role("button", name="Edit").click()
@@ -228,8 +227,7 @@ def _existing_environment_interactions(page, env_name, time_to_build_env=3*60*10
     page.get_by_text("Delete environment").click()
     page.get_by_role("button", name="Delete").click()
 
-    assert not page.get_by_role("button", name=env_name).is_visible()
-
+    expect(page.get_by_role("button", name=env_name)).not_to_be_visible()
 
 
 def test_integration(page: Page, test_config, screenshot):

--- a/test/playwright/test_ux.py
+++ b/test/playwright/test_ux.py
@@ -166,70 +166,70 @@ def _existing_environment_interactions(page, env_name, time_to_build_env=3*60*10
     # edit existing environment throught the YAML editor
     page.get_by_role("button", name=env_name).click()
     page.get_by_role("button", name="Edit").click()
-    page.get_by_label("Switch to YAML Editor").check()
-    if screenshot:
-        page.screenshot(path="test-results/conda-store-yaml-editor.png")
-    page.get_by_text("- rich").click()
-    page.get_by_text("channels: - conda-forgedependencies: - rich - pip: - nothing - ipykernel").fill("channels:\n  - conda-forge\ndependencies:\n  - rich\n  - python\n  - pip:\n      - nothing\n  - ipykernel\n\n")
-    page.get_by_role("button", name="Save").click()
-    # wait until the status is `Completed`
-    completed = page.get_by_text("Completed", exact=False)
-    completed.wait_for(state='attached', timeout=time_to_build_env)
+    # page.get_by_label("Switch to YAML Editor").check()
+    # if screenshot:
+    #     page.screenshot(path="test-results/conda-store-yaml-editor.png")
+    # page.get_by_text("- rich").click()
+    # page.get_by_text("channels: - conda-forgedependencies: - rich - pip: - nothing - ipykernel").fill("channels:\n  - conda-forge\ndependencies:\n  - rich\n  - python\n  - pip:\n      - nothing\n  - ipykernel\n\n")
+    # page.get_by_role("button", name="Save").click()
+    # # wait until the status is `Completed`
+    # completed = page.get_by_text("Completed", exact=False)
+    # completed.wait_for(state='attached', timeout=time_to_build_env)
 
-    # ensure the namespace is expanded
-    if not page.get_by_role("button", name=env_name).is_visible():
-        # click to expand the `username` name space (but not click the +)
-        page.get_by_role("button", name="username Create a new environment in the username namespace").click()
+    # # ensure the namespace is expanded
+    # if not page.get_by_role("button", name=env_name).is_visible():
+    #     # click to expand the `username` name space (but not click the +)
+    #     page.get_by_role("button", name="username Create a new environment in the username namespace").click()
 
-    # edit existing environment
-    page.get_by_role("button", name=env_name).click()
-    page.get_by_role("button", name="Edit").click()
-    # page.get_by_placeholder("Enter here the description of your environment").click()
-    # change the description
-    page.get_by_placeholder("Enter here the description of your environment").fill("new description")
-    # change the vesion spec of an existing package
-    page.get_by_role("row", name="ipykernel", exact=False).get_by_role("button").first.click()
-    page.get_by_role("option", name=">=").click()
-    # Note: purposefully not testing version constraint since there is inconsistent behavior here
+    # # edit existing environment
+    # page.get_by_role("button", name=env_name).click()
+    # page.get_by_role("button", name="Edit").click()
+    # # page.get_by_placeholder("Enter here the description of your environment").click()
+    # # change the description
+    # page.get_by_placeholder("Enter here the description of your environment").fill("new description")
+    # # change the vesion spec of an existing package
+    # page.get_by_role("row", name="ipykernel", exact=False).get_by_role("button").first.click()
+    # page.get_by_role("option", name=">=").click()
+    # # Note: purposefully not testing version constraint since there is inconsistent behavior here
 
-    # add a new package
-    page.get_by_role("button", name="+ Add Package").click()
-    page.get_by_label("Enter package").fill("click")
-    page.get_by_role("option", name="click", exact=True).click()
-    # Note: purposefully not testing version constraint since there is inconsistent behavior here
+    # # add a new package
+    # page.get_by_role("button", name="+ Add Package").click()
+    # page.get_by_label("Enter package").fill("click")
+    # page.get_by_role("option", name="click", exact=True).click()
+    # # Note: purposefully not testing version constraint since there is inconsistent behavior here
     
-    # delete a package
-    page.get_by_role("row", name="rich", exact=False).get_by_test_id("RemovePackageTest").click()
+    # # delete a package
+    # page.get_by_role("row", name="rich", exact=False).get_by_test_id("RemovePackageTest").click()
 
-    # promote a package installed as dependency to specified package
-    page.locator("#infScroll > .infinite-scroll-component__outerdiv > .infinite-scroll-component > div > div > .MuiButtonBase-root").first.click()
+    # # promote a package installed as dependency to specified package
+    # page.locator("#infScroll > .infinite-scroll-component__outerdiv > .infinite-scroll-component > div > div > .MuiButtonBase-root").first.click()
     
-    # delete conda-forge channel
-    page.get_by_test_id("DeleteIcon").click()
-    # add conda-forge channel
-    page.get_by_role("button", name="+ Add Channel").click()
-    page.get_by_label("Enter channel").fill("conda-forge")
-    page.get_by_label("Enter channel").press("Enter")
-    # click save to start the new env build
-    page.get_by_role("button", name="Save").click()
+    # # delete conda-forge channel
+    # page.get_by_test_id("DeleteIcon").click()
+    # # add conda-forge channel
+    # page.get_by_role("button", name="+ Add Channel").click()
+    # page.get_by_label("Enter channel").fill("conda-forge")
+    # page.get_by_label("Enter channel").press("Enter")
+    # # click save to start the new env build
+    # page.get_by_role("button", name="Save").click()
 
-    # wait until the status is `Completed`
-    completed = page.get_by_text("Completed", exact=False)
-    completed.wait_for(state='attached', timeout=time_to_build_env)
+    # # wait until the status is `Completed`
+    # completed = page.get_by_text("Completed", exact=False)
+    # completed.wait_for(state='attached', timeout=time_to_build_env)
 
 
-    # Edit -> Cancel editing
-    page.get_by_role("button", name=env_name).click()
-    page.get_by_role("button", name="Edit").click()
-    page.get_by_role("button", name="Cancel").click()
+    # # Edit -> Cancel editing
+    # page.get_by_role("button", name=env_name).click()
+    # page.get_by_role("button", name="Edit").click()
+    # page.get_by_role("button", name="Cancel").click()
 
-    # Edit -> Delete environment
-    page.get_by_role("button", name="Edit").click()
-    page.get_by_text("Delete environment").click()
-    page.get_by_role("button", name="Delete").click()
+    # # Edit -> Delete environment
+    # page.get_by_role("button", name="Edit").click()
+    # page.get_by_text("Delete environment").click()
+    # page.get_by_role("button", name="Delete").click()
 
-    time.sleep(5)  # wait for it to render, flaky otherwise
-    assert not page.get_by_role("button", name=env_name).is_visible()
+    # time.sleep(5)  # wait for it to render, flaky otherwise
+    # assert not page.get_by_role("button", name=env_name).is_visible()
 
 
 


### PR DESCRIPTION
Fixe flaky playwright tests. 

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
<!-- What is the purpose of this pull request? -->

This adds a custom default timeout for all tests which is much longer than the default of 5 seconds. This allows the page to load and the backend to catchup before raising an error. 


This pull request:

- adds 30s default timeout for all playwright tests


## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

