### PR TITLE
Removing environment pagination

### DIFF
--- a/src/features/environments/components/Environments.tsx
+++ b/src/features/environments/components/Environments.tsx
@@ -100,8 +100,6 @@ const BaseEnvironments = ({
 
   const getEnvironments = async () => {
     const { data: environmentsData } = await triggerQuery({
-      page: state.page,
-      size,
       search: state.search
     });
 
@@ -114,7 +112,7 @@ const BaseEnvironments = ({
   };
 
   const handleChange = debounce(async (value: string) => {
-    const { data } = await triggerQuery({ page: 1, size, search: value });
+    const { data } = await triggerQuery({ search: value });
 
     if (data) {
       dispatch({
@@ -126,8 +124,6 @@ const BaseEnvironments = ({
 
   const next = async () => {
     const { data } = await triggerQuery({
-      page: state.page + 1,
-      size,
       search: state.search
     });
 

--- a/src/features/environments/environmentsApiSlice.ts
+++ b/src/features/environments/environmentsApiSlice.ts
@@ -6,10 +6,10 @@ export const environmentsApiSlice = apiSlice.injectEndpoints({
   endpoints: builder => ({
     fetchEnvironments: builder.query<
       IApiResponse<Environment[]>,
-      { page: number; size: number; search: string }
+      { search: string }
     >({
       query: dto =>
-        `/api/v1/environment/?page=${dto.page}&size=${dto.size}&search=${dto.search}`
+        `/api/v1/environment/?search=${dto.search}`
     })
   })
 });


### PR DESCRIPTION
Fixes # .
Fixes issue 312, where only the first page of environments get loaded: https://github.com/conda-incubator/conda-store-ui/issues/312

## Description
It seems that the pagination of environments does not happen, however the environments are still loaded as if they are, with only 100 per page. So, if a user has over 100 environments, the UI will only show the first 100 (in alphabetical order). 

This pull request:
Removes size and page number from the api call, as well as the corresponding functions.
Changes were tested locally.