### PR TITLE
Tests pass (but with console errors and warnings)

### DIFF
--- a/src/features/requestedPackages/components/AddRequestedPackage.tsx
+++ b/src/features/requestedPackages/components/AddRequestedPackage.tsx
@@ -178,6 +178,7 @@ export const AddRequestedPackage = ({
         <StyledIconButton
           onClick={() => onCancel(false)}
           data-testid="cancelIcon"
+          theme={theme}
         >
           <DeleteIconAlt />
         </StyledIconButton>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -149,8 +149,6 @@ export const condaStoreTheme = createTheme(baseTheme, {
   }
 });
 
-export const theme = condaStoreTheme;
-
 export const themeDecorator = (func: any) => (
   <ThemeProvider theme={condaStoreTheme}>{func()}</ThemeProvider>
 );

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -149,6 +149,8 @@ export const condaStoreTheme = createTheme(baseTheme, {
   }
 });
 
+export const theme = condaStoreTheme;
+
 export const themeDecorator = (func: any) => (
   <ThemeProvider theme={condaStoreTheme}>{func()}</ThemeProvider>
 );

--- a/test/components/BlockContainerEditMode.test.tsx
+++ b/test/components/BlockContainerEditMode.test.tsx
@@ -16,7 +16,7 @@ describe("<BlockContainerEditMode />", () => {
         </BlockContainerEditMode>
       )
     );
-    expect(container).toHaveTextContent("Switch to YAML Editor");
+    expect(container).toHaveTextContent("YAML");
   });
 
   it("should call onToggleEditMode when the user switches the view", () => {
@@ -32,7 +32,9 @@ describe("<BlockContainerEditMode />", () => {
         </BlockContainerEditMode>
       )
     );
-    const switchButton = component.getByLabelText("Switch to Standard View");
+    const switchButton = component.getByLabelText("YAML", {
+      exact: false
+    });
     fireEvent.click(switchButton);
     expect(onToggleEditorView).toHaveBeenCalled();
   });

--- a/test/environmentCreate/SpecificationCreate.test.tsx
+++ b/test/environmentCreate/SpecificationCreate.test.tsx
@@ -30,7 +30,7 @@ describe("<SpecificationCreate />", () => {
   });
 
   it("should switch the view to the yaml editor", () => {
-    const switchButton = component.getByLabelText("Switch to YAML Editor");
+    const switchButton = component.getByLabelText("YAML", { exact: false });
     fireEvent.click(switchButton);
 
     const vatSelectInput = component.container.querySelector(
@@ -45,7 +45,7 @@ describe("<SpecificationCreate />", () => {
 
     expect(mockOnCreateEnvironment).toHaveBeenCalled();
 
-    const switchButton = component.getByLabelText("Switch to YAML Editor");
+    const switchButton = component.getByLabelText("YAML", { exact: false });
     fireEvent.click(switchButton);
 
     fireEvent.click(createButton);
@@ -56,7 +56,7 @@ describe("<SpecificationCreate />", () => {
   });
 
   it("should update channels and dependencies", async () => {
-    const switchButton = component.getByLabelText("Switch to YAML Editor");
+    const switchButton = component.getByLabelText("YAML", { exact: false });
     fireEvent.click(switchButton);
 
     const code = stringify({
@@ -69,7 +69,9 @@ describe("<SpecificationCreate />", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("conda-channel")).not.toBeNull();
+      expect(
+        screen.getByText("conda-channel", { exact: false })
+      ).not.toBeNull();
     });
 
     const emptyCode = stringify({

--- a/test/environmentDetails/SpecificationEdit.test.tsx
+++ b/test/environmentDetails/SpecificationEdit.test.tsx
@@ -52,7 +52,7 @@ describe("<SpecificationEdit />", () => {
         </Provider>
       )
     );
-    const switchButton = component.getByLabelText("Switch to YAML Editor");
+    const switchButton = component.getByLabelText("YAML", { exact: false });
     fireEvent.click(switchButton);
 
     act(() => {
@@ -60,9 +60,7 @@ describe("<SpecificationEdit />", () => {
       store.dispatch(updateChannels(["conda-store"]));
     });
 
-    expect(
-      component.queryByText("Switch to Standard View")
-    ).toBeInTheDocument();
+    expect(component.queryByText("YAML", { exact: false })).toBeInTheDocument();
   });
 
   it("should cancel environment edition", () => {
@@ -93,7 +91,7 @@ describe("<SpecificationEdit />", () => {
         </Provider>
       )
     );
-    const switchButton = component.getByLabelText("Switch to YAML Editor");
+    const switchButton = component.getByLabelText("YAML", { exact: false });
     fireEvent.click(switchButton);
 
     const code = stringify({
@@ -106,7 +104,9 @@ describe("<SpecificationEdit />", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("conda-channel")).not.toBeNull();
+      expect(
+        screen.getByText("conda-channel", { exact: false })
+      ).not.toBeNull();
     });
 
     const emptyCode = stringify({

--- a/test/environments/EnvironmentList.test.tsx
+++ b/test/environments/EnvironmentList.test.tsx
@@ -57,7 +57,7 @@ describe("<EnvironmentsList />", () => {
       )
     );
 
-    expect(component.container).toHaveTextContent("Shared environments");
+    expect(component.container).toHaveTextContent("Shared Environments");
     expect(component.container).toHaveTextContent("default");
   });
 });

--- a/test/testutils.tsx
+++ b/test/testutils.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from "@mui/material";
 import React from "react";
 import { CondaSpecification } from "../src/common/models";
-import { theme } from "../src/theme";
+import { condaStoreTheme } from "../src/theme";
 
 export const NAMESPACES = [
   {
@@ -90,5 +90,5 @@ export const BUILD = {
 };
 
 export const mockTheme = (children: any) => {
-  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+  return <ThemeProvider theme={condaStoreTheme}>{children}</ThemeProvider>;
 };


### PR DESCRIPTION
I couldn't find any GitHub issue about the Jest tests being broken.

## Description
This pull request:

- Allows `yarn test` to run and exit without errors
- (But does not fix any of the uncaught errors that get generated during test execution and logged to the console but do not actually cause any of the tests to fail.) 

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
