### PR TITLE
Set explicit height on infinite scroll target

### DIFF
--- a/src/styles/StyledScrollContainer.tsx
+++ b/src/styles/StyledScrollContainer.tsx
@@ -4,6 +4,7 @@ import { styled } from "@mui/system";
 export const StyledScrollContainer = styled(Box, {
   shouldForwardProp: prop => prop !== "styleType"
 })<{ styleType?: string }>(({ theme: { palette } }) => ({
+  height: "100%",
   overflowY: "scroll",
   overflowX: "hidden",
   paddingRight: "0px",


### PR DESCRIPTION
Fixes #312.

### Description

While I was reviewing #356, I think I discovered why the infinite scroll React component wasn't doing its job. For whatever reason, it requires that the scrollable target has its height explicitly set—so height 100% rather than height auto.

### Pull request checklist

- [x] Did you test this change locally?
   - Yes, but I only tested this with environments in a single namespace
- [x] Did you update the documentation (if required)?
    - No docs to update
- [ ] Did you add/update relevant tests for this change (if required)?
    - I need to see if there's a way to add an automated regression test for this