### PR TITLE
Store environment form values in hash object 

### DIFF
--- a/src/features/dependencies/components/Dependencies.tsx
+++ b/src/features/dependencies/components/Dependencies.tsx
@@ -11,7 +11,7 @@ import {
 import { Dependency } from "../../../common/models";
 import { DependenciesItem } from "./DependenciesItem";
 import { useAppDispatch, useAppSelector } from "../../../hooks";
-import { dependencyPromoted } from "../../../features/requestedPackages";
+import { requestedPackageAdded } from "../../environmentCreate/environmentCreateSlice";
 import { ArrowIcon } from "../../../components";
 
 export interface IDependenciesProps {
@@ -91,7 +91,21 @@ export const Dependencies = ({
                   <DependenciesItem
                     mode={mode}
                     dependency={dependency}
-                    handleClick={() => dispatch(dependencyPromoted(dependency))}
+                    handleClick={() => {
+                      if (!selectedEnvironment) {
+                        return;
+                      }
+                      const {
+                        namespace: { name: namespaceName },
+                        name: environmentName
+                      } = selectedEnvironment;
+                      dispatch(
+                        requestedPackageAdded([
+                          `${namespaceName}/${environmentName}`,
+                          `${dependency.name}==${dependency.version}`
+                        ])
+                      );
+                    }}
                   />
                 </Box>
               ))}

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -20,25 +20,28 @@ import {
   StyledEditPackagesTableCell
 } from "../../../styles";
 import { AddRequestedPackage } from "../../requestedPackages";
-import { requestedPackagesChanged } from "../environmentCreateSlice";
+import { requestedPackageAdded } from "../environmentCreateSlice";
 import { CreateEnvironmentPackagesTableRow } from "./CreateEnvironmentPackagesTableRow";
+import { CondaSpecificationPip } from "../../../common/models/CondaSpecificationPip";
 
 interface ICreateEnvironmentPackagesProps {
   /**
    * @param requestedPackages list of created packages
    */
-  requestedPackages: string[];
+  namespaceName: string;
+  requestedPackages: (string | CondaSpecificationPip)[];
 }
 
 export const CreateEnvironmentPackages = ({
+  namespaceName,
   requestedPackages
 }: ICreateEnvironmentPackagesProps) => {
   const dispatch = useAppDispatch();
   const [isAdding, setIsAdding] = useState(false);
   const { palette } = useTheme();
 
-  const filteredRequestedPackages = useMemo(
-    () => requestedPackages.filter(item => typeof item !== "object"),
+  const filteredRequestedPackages: string[] = useMemo(
+    () => requestedPackages.filter(item => typeof item === "string") as string[],
     [requestedPackages]
   );
 
@@ -87,6 +90,7 @@ export const CreateEnvironmentPackages = ({
             {filteredRequestedPackages.map(requestedPackage => (
               <CreateEnvironmentPackagesTableRow
                 key={requestedPackage}
+                namespaceName={namespaceName}
                 requestedPackage={requestedPackage}
               />
             ))}
@@ -97,8 +101,8 @@ export const CreateEnvironmentPackages = ({
             <AddRequestedPackage
               onSubmit={(value: string) =>
                 dispatch(
-                  requestedPackagesChanged([
-                    ...filteredRequestedPackages,
+                  requestedPackageAdded([
+                    `${namespaceName}/new-environment`,
                     value
                   ])
                 )

--- a/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
@@ -21,10 +21,12 @@ interface IProps {
   /**
    * @param requestedPackage requested package
    */
+  namespaceName: string;
   requestedPackage: string;
 }
 
 const BaseCreateEnvironmentPackagesTableRow = ({
+  namespaceName,
   requestedPackage
 }: IProps) => {
   const dispatch = useAppDispatch();
@@ -35,10 +37,13 @@ const BaseCreateEnvironmentPackagesTableRow = ({
     const updatedPackage = `${name}${value}${version}`;
 
     dispatch(
-      requestedPackageUpdated({
-        currentPackage: requestedPackage,
-        updatedPackage
-      })
+      requestedPackageUpdated([
+        `${namespaceName}/new-environment`,
+        {
+          currentPackage: requestedPackage,
+          updatedPackage
+        }
+      ])
     );
   };
 
@@ -52,15 +57,23 @@ const BaseCreateEnvironmentPackagesTableRow = ({
     const updatedPackage = `${name}${pkgConstraint}${value}`;
 
     dispatch(
-      requestedPackageUpdated({
-        currentPackage: requestedPackage,
-        updatedPackage
-      })
+      requestedPackageUpdated([
+        `${namespaceName}/new-environment`,
+        {
+          currentPackage: requestedPackage,
+          updatedPackage
+        }
+      ])
     );
   };
 
   const handleRemovePackage = (requestedPackage: string) => {
-    dispatch(requestedPackageRemoved(requestedPackage));
+    dispatch(
+      requestedPackageRemoved([
+        `${namespaceName}/new-environment`,
+        requestedPackage
+      ])
+    );
   };
 
   return (

--- a/src/features/environmentDetails/components/EnvironmentDetailsHeader.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetailsHeader.tsx
@@ -16,15 +16,15 @@ interface IEnvironmentDetailsHeaderProps {
    * @param namespace namespace of the environment
    * @param onUpdateName change environment name
    */
-  envName?: string;
-  namespace?: string;
+  envName: string;
+  namespace: string;
   showEditButton: boolean | undefined;
-  onUpdateName: (value: string) => void;
+  onUpdateName?: (value: string) => void;
 }
 
 export const EnvironmentDetailsHeader = ({
   envName = "",
-  namespace,
+  namespace = "",
   onUpdateName,
   showEditButton = true
 }: IEnvironmentDetailsHeaderProps) => {
@@ -57,9 +57,9 @@ export const EnvironmentDetailsHeader = ({
           {mode === EnvironmentDetailsModes.READ && (
             <StyledButtonPrimary
               disabled={!showEditButton}
-              onClick={() =>
-                dispatch(modeChanged(EnvironmentDetailsModes.EDIT))
-              }
+              onClick={() => {
+                dispatch(modeChanged(EnvironmentDetailsModes.EDIT));
+              }}
             >
               Edit
             </StyledButtonPrimary>
@@ -103,7 +103,8 @@ export const EnvironmentDetailsHeader = ({
               }
             }}
             size="small"
-            onChange={e => onUpdateName(e.target.value)}
+            value={envName}
+            onChange={e => onUpdateName && onUpdateName(e.target.value)}
           />
           {/* <StyledButtonPrimary>Archive</StyledButtonPrimary> */}
         </>

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -14,7 +14,7 @@ interface IEnvMetadataProps {
    * @param mode change whether the component only displays the list of builds, edit the environment description or create a new description
    * @param onUpdateDescription change environment description
    */
-  description?: any;
+  description: string;
   mode: "create" | "read-only" | "edit";
   currentBuildId?: number | undefined;
   selectedBuildId?: number;
@@ -27,7 +27,7 @@ interface IEnvMetadataProps {
 
 export const EnvMetadata = ({
   mode,
-  description = "",
+  description,
   currentBuildId,
   selectedBuildId,
   specificationIsChanged,
@@ -58,7 +58,7 @@ export const EnvMetadata = ({
     <BlockContainer title="Environment Metadata">
       <Description
         mode={mode}
-        description={description || undefined}
+        description={description}
         onChangeDescription={onUpdateDescription}
       />
       <div

--- a/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
@@ -19,27 +19,38 @@ import {
 } from "../../../styles";
 import { CondaSpecificationPip } from "../../../common/models";
 import { useAppDispatch } from "../../../hooks";
-import { packageAdded } from "../requestedPackagesSlice";
 import { ArrowIcon } from "../../../components";
+import { requestedPackageAdded } from "../../environmentCreate/environmentCreateSlice";
 
 export interface IRequestedPackagesEditProps {
   /**
    * @param packageList list of packages that we get from the API
    */
+  environmentName: string;
+  namespaceName: string;
   packageList: (string | CondaSpecificationPip)[];
   onDefaultEnvIsChanged?: (isChanged: boolean) => void;
 }
 
 export const RequestedPackagesEdit = ({
+  environmentName,
+  namespaceName,
   packageList,
   onDefaultEnvIsChanged
 }: IRequestedPackagesEditProps) => {
+  console.log("rendering RequestedPackagesEdit, packageList", packageList);
+
   const dispatch = useAppDispatch();
   const [isAdding, setIsAdding] = useState(false);
   const { palette } = useTheme();
 
   const handleSubmit = (packageName: string) => {
-    dispatch(packageAdded(packageName));
+    dispatch(
+      requestedPackageAdded([
+        `${namespaceName}/${environmentName}`,
+        packageName
+      ])
+    );
     if (onDefaultEnvIsChanged) {
       onUpdateDefaultEnvironment(false);
     }
@@ -114,6 +125,8 @@ export const RequestedPackagesEdit = ({
             {filteredPackageList.map(requestedPackage => (
               <RequestedPackagesTableRow
                 key={requestedPackage}
+                environmentName={environmentName}
+                namespaceName={namespaceName}
                 requestedPackage={requestedPackage}
                 onDefaultEnvIsChanged={onUpdateDefaultEnvironment}
               />

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -13,17 +13,24 @@ import {
   StyledRequestedPackagesTableCell
 } from "../../../styles";
 import { requestedPackageParser } from "../../../utils/helpers";
-import { packageRemoved, packageUpdated } from "../requestedPackagesSlice";
+import {
+  requestedPackageRemoved,
+  requestedPackageUpdated
+} from "../../environmentCreate/environmentCreateSlice";
 
 interface IRequestedPackagesTableRowProps {
   /**
    * @param requestedPackage requested package
    */
+  environmentName: string;
+  namespaceName: string;
   requestedPackage: string;
   onDefaultEnvIsChanged?: (isChanged: boolean) => void;
 }
 
 const BaseRequestedPackagesTableRow = ({
+  environmentName,
+  namespaceName,
   requestedPackage,
   onDefaultEnvIsChanged
 }: IRequestedPackagesTableRowProps) => {
@@ -54,7 +61,10 @@ const BaseRequestedPackagesTableRow = ({
     const updatedPackage = `${name}${pkgConstraint}${value}`;
 
     dispatch(
-      packageUpdated({ currentPackage: requestedPackage, updatedPackage })
+      requestedPackageUpdated([
+        `${namespaceName}/${environmentName}`,
+        { currentPackage: requestedPackage, updatedPackage }
+      ])
     );
     onUpdateDefaultEnvironment(false);
   };
@@ -63,13 +73,26 @@ const BaseRequestedPackagesTableRow = ({
     const updatedPackage = `${name}${value}${version ? version : ""}`;
 
     dispatch(
-      packageUpdated({ currentPackage: requestedPackage, updatedPackage })
+      requestedPackageUpdated([
+        `${namespaceName}/${environmentName}`,
+        { currentPackage: requestedPackage, updatedPackage }
+      ])
     );
     onUpdateDefaultEnvironment(false);
   };
 
   const handleRemove = () => {
-    dispatch(packageRemoved(requestedPackage));
+    console.log(
+      "removing package",
+      `${namespaceName}/${environmentName}`,
+      requestedPackage
+    );
+    dispatch(
+      requestedPackageRemoved([
+        `${namespaceName}/${environmentName}`,
+        requestedPackage
+      ])
+    );
     onUpdateDefaultEnvironment(false);
   };
 

--- a/src/features/requestedPackages/requestedPackagesSlice.ts
+++ b/src/features/requestedPackages/requestedPackagesSlice.ts
@@ -55,9 +55,6 @@ export const requestedPackagesSlice = createSlice({
         p => p !== action.payload
       );
     },
-    packageAdded: (state, action: PayloadAction<string>) => {
-      state.requestedPackages.push(action.payload);
-    },
     buildPackagesCacheAdded: (
       state,
       action: PayloadAction<{
@@ -127,6 +124,5 @@ export const {
   dependencyPromoted,
   packageUpdated,
   packageRemoved,
-  packageAdded,
   buildPackagesCacheAdded
 } = requestedPackagesSlice.actions;

--- a/src/features/requestedPackages/stories/RequestedPackagesEdit.stories.tsx
+++ b/src/features/requestedPackages/stories/RequestedPackagesEdit.stories.tsx
@@ -18,6 +18,10 @@ export default {
 
 export const Primary = () => (
   <Provider store={store}>
-    <RequestedPackagesEdit packageList={packageList} />
+    <RequestedPackagesEdit
+      namespaceName="test_namespace"
+      environmentName="test_environment"
+      packageList={packageList}
+    />
   </Provider>
 );

--- a/src/utils/helpers/parseCodeEditorContent.ts
+++ b/src/utils/helpers/parseCodeEditorContent.ts
@@ -1,0 +1,74 @@
+import { parse } from "yaml";
+import { CondaSpecification } from "../../common/models";
+
+export default function parseCodeEditorContent(
+  code: string
+): Pick<CondaSpecification, "channels" | "dependencies" | "variables"> {
+  let { channels, dependencies, variables } = parse(code) || {};
+
+  // Note: the [null] checks are due to empty lists in the pretty-printed case
+  // of formatCode
+  if (
+    !channels ||
+    channels.length === 0 ||
+    (channels.length === 1 && channels[0] === null)
+  ) {
+    channels = [];
+  } else if (channels[channels.length - 1] === null) {
+    channels.pop();
+  }
+
+  if (
+    !dependencies ||
+    dependencies.length === 0 ||
+    (dependencies.length === 1 && dependencies[0] === null)
+  ) {
+    dependencies = [];
+  } else if (dependencies[dependencies.length - 1] === null) {
+    dependencies.pop();
+  }
+
+  if (!variables || Object.keys(variables).length === 0) {
+    variables = {};
+  }
+
+  if (channels.some((c: unknown) => typeof c !== "string")) {
+    throw new Error(
+      "Found non-string member of channels while parsing Yaml spec"
+    );
+  }
+
+  const nonStringDeps = dependencies.filter(
+    (d: unknown) => typeof d !== "string"
+  );
+  if (nonStringDeps.length) {
+    if (nonStringDeps.length > 1) {
+      throw new Error(
+        "Found more than one non-string member of dependencies while parsing Yaml spec"
+      );
+    }
+
+    if (
+      !Array.isArray(nonStringDeps[0].pip) ||
+      nonStringDeps[0].pip.some((pipDep: unknown) => typeof pipDep !== "string")
+    ) {
+      throw new Error(
+        "Found non-string, non-CondaSpecificationPip member of dependencies while parsing Yaml spec"
+      );
+    }
+  }
+
+  if (Object.keys(variables).some((k: unknown) => typeof k !== "string")) {
+    throw new Error(
+      "Found non-string key in variables while parsing Yaml spec"
+    );
+  }
+
+  if (Object.values(variables).some((v: unknown) => typeof v !== "string")) {
+    throw new Error(
+      "Found non-string value in variables while parsing Yaml spec"
+    );
+  }
+
+  return { channels, dependencies, variables };
+}

--- a/test/environmentDetails/EnvironmentDetailsHeader.test.tsx
+++ b/test/environmentDetails/EnvironmentDetailsHeader.test.tsx
@@ -17,6 +17,7 @@ describe("<EnvironmentDetailsHeader />", () => {
         <Provider store={store}>
           <EnvironmentDetailsHeader
             envName="Environment name"
+            namespace="test-namespace"
             onUpdateName={jest.fn()}
             showEditButton={true}
           />
@@ -42,6 +43,7 @@ describe("<EnvironmentDetailsHeader />", () => {
         <Provider store={store}>
           <EnvironmentDetailsHeader
             envName="Environment name"
+            namespace="test-namespace"
             onUpdateName={jest.fn()}
             showEditButton={true}
           />
@@ -64,6 +66,7 @@ describe("<EnvironmentDetailsHeader />", () => {
         <Provider store={store}>
           <EnvironmentDetailsHeader
             envName={undefined}
+            namespace="test-namespace"
             onUpdateName={mockOnUpdateName}
             showEditButton={true}
           />


### PR DESCRIPTION
- Create new environment form key: "{namespace}/new-environment"
- Edit existing environment form key: "{namespace}/{environment}"

Fixes #394.

### IMPORTANT: DRAFT

I'm uploading this PR as a draft so folks can take a look if they're curious. But I'm not sure it should be merged. I think we should first see if #389 prevents the issues mentioned in #385 from surfacing. 

Why?

- This PR is a lot of changes -> risky -> might not be worth it
- This PR took a lot of work but it's still not quite finished, it will require even more work -> might not be worth the extra effort if #389 takes care of the issues that this PR is trying to fix (see #385)
  -  Still not quite finished. For example, when clicking the edit button the values of the environment are synced to the form, but to prevent previously editing form values from getting clobbered, I need to check first if the environment form exists.
  - But here's the catch: when the user clicks an environment, they should see the most current values, and when they click the edit button, do they expect the form to contain the current values or their previously edited values? I don't find the user experience intuitive at all

### Description

This pull request enables a user to start filling out a form to create an environment in a particular namespace, abandon the form, start a second form to create another environment in a different namespace, then return to the first form with all of their changes still in place. It persists state between `pushState` navigations, such as clicking a link or use the back button, but it does not persist state between page loads such as if the user presses the refresh button, opens a link in a new tab or window, or enters a URL directly into the browser address bar. It stores form values in a hash object in app memory

### Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?
