### PR TITLE
Remove manual npm publish step

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,4 +26,31 @@
    npm publish --verbose --access public conda-store-ui.tgz --dry-run
    ```
 
-6. If the dry run looks good, continue with the release checklist items
+If the dry run looks good, continue with the release checklist items.
+
+## Troubleshooting notes
+
+* If there are issues with the [GitHub Release UI](https://github.com/conda-incubator/conda-store-ui/releases/new), ensure that whatever code you published is checked into git, then tag and push the commit and tag:
+
+   ```bash
+   # use the same version here as in package.json, but without a leading `v`
+   git tag -a YYYY.M.ReleaseNumber
+
+   # push to upstream
+   git push && git push --tags
+   ```
+
+* In case the [Release GitHub Actions workflow][release-action] fails, publish to npmjs manually. You need access to the [conda-store-ui npm package][cs-ui-npm] for this:
+
+   ```bash
+   # you likely need to login first
+   # npm login --registry https://registry.npmjs.org --scope @conda-store-ui
+
+   # publish release to npmjs
+   npm publish --verbose --access public conda-store-ui.tgz
+   ```
+
+<!-- Link -->
+
+[cs-ui-npm]: https://www.npmjs.com/package/@conda-store/conda-store-ui
+[release-action]: https://github.com/conda-incubator/conda-store-ui/blob/main/.github/workflows/release.yml

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,22 +26,4 @@
    npm publish --verbose --access public conda-store-ui.tgz --dry-run
    ```
 
-6. If the dry run looks good, publish to npmjs:
-
-   ```bash
-   # you will more than likely need to login first
-   # npm login --registry https://registry.npmjs.org --scope @conda-store-ui
-
-   # publish release to npmjs
-   npm publish --verbose --access public conda-store-ui.tgz
-   ```
-
-7. Ensure that whatever code you published is checked into git, then tag and push the commit and tag
-
-```bash
-# use the same version here as in package.json, but without a leading `v`
-git tag -a YYYY.M.ReleaseNumber
-
-# push to upstream
-git push && git push --tags
-```
+6. If the dry run looks good, continue with the release checklist items


### PR DESCRIPTION
Fixes # .
<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
<!-- What is the purpose of this pull request? -->

This pull request:

Removes the manual npm publish steps. This is not required because the release GitHub action has the relevant permission to publish to npm, and it will auto-triggerred when a new tag is created with a release on github.
  
## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
