### PR TITLE
Bump default CONDA_STORE_SERVER_VERSION

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,4 @@ REACT_APP_LOGOUT_PAGE_URL=http://localhost:8080/conda-store/logout?next=/
 
 # If you want to use a version other than the pinned conda-store-server version
 # Set the CONDA_STORE_SERVER_VERSION to the package version that you want
-# CONDA_STORE_SERVER_VERSION="2023.10.1"
+# CONDA_STORE_SERVER_VERSION="2024.3.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   conda-store-worker:
-    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2023.10.1}
+    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2024.3.1}
     volumes:
       - ./docker/assets/environments:/opt/environments:ro
       - ./docker/assets/conda_store_config.py:/opt/conda_store/conda_store_config.py:ro
@@ -18,7 +18,7 @@ services:
       ]
 
   conda-store-server:
-    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2023.10.1}
+    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2024.3.1}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Set it to the last version in which the server-vendored version of the UI was still working (i.e., 2023.3.1 at localhost:8080/conda-store).

Does not fix, but it is tangentially related to:

- https://github.com/conda-incubator/conda-store-ui/issues/408.