### PR TITLE
Remove unnecessary scroll bars from specification tables

### DIFF
--- a/src/features/requestedPackages/components/RequestedPackageList.tsx
+++ b/src/features/requestedPackages/components/RequestedPackageList.tsx
@@ -47,7 +47,7 @@ export const RequestedPackageList = ({
       </StyledAccordionSummary>
       <StyledAccordionDetails sx={{ padding: 0 }}>
         <TableContainer>
-          <Table sx={{ width: "420px", tableLayout: "fixed" }}>
+          <Table sx={{ width: "100%", tableLayout: "fixed" }}>
             <TableHead>
               <TableRow>
                 <TableCell sx={{ fontSize: "13px" }}>Package</TableCell>

--- a/src/styles/StyledAccordionDetails.tsx
+++ b/src/styles/StyledAccordionDetails.tsx
@@ -15,8 +15,8 @@ export const StyledAccordionDetails = styled(AccordionDetails, {
         ? `1px solid ${palette.secondary.light}`
         : "1px solid #BCBFC4",
     borderTop: "none",
-    borderRadius: styleType === "grayscale" ? "0px 0px 5px 5px" : "Opx",
-    overflowY: "scroll",
+    borderRadius: styleType === "grayscale" ? "0px 0px 5px 5px" : "0px",
+    overflowY: "auto",
     "&::-webkit-scrollbar-thumb": {
       backgroundColor: styleType === "grayscale" ? "#EBECEE" : "#DADCE0",
       borderRadius: "5px",


### PR DESCRIPTION
### Before

- Unnecessary vertical scroll bars on the tables labeled "Requested packages" and "Channels"
- Unnecessary horizontal scroll bar on "Requested packages" table

![screenshot](https://github.com/user-attachments/assets/44113d54-d322-411a-bb16-434ec01afcc0)

### After 

No more unnecessary scroll bars.

![screenshot](https://github.com/user-attachments/assets/beee73da-dd71-4591-9891-748441aa71d2)

