### PR TITLE
DEV - Bump conda-store-ui version - post release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -39,7 +39,7 @@ Release captain responsible - <@gh_username>
   - Add release notes in the field below [^github-activity].
 - [ ] Confirm that the release completed
   - [The `release` GitHub action job](https://github.com/conda-incubator/conda-store-ui/blob/main/.github/workflows/release.yml) has been completed successfully in the [actions tab](https://github.com/conda-incubator/conda-store-ui/actions).
-- Once the release is completed open a PR to adjust the `version` in `package.json` to the next release-dev (e.g., `2023.9.1-dev`)
+- [ ] Once the release is completed open a PR to adjust the `version` in `package.json` to the next release-dev (e.g., `2023.9.1-dev`)
 - [ ] Celebrate, you're done! 🎉
 
 [^github-activity]: If you wish, use [`github-activity` to generate a changelog](https://github.com/choldgraf/github-activity), e.g. `github-activity conda-incubator/conda-store --since 2023.9.1 --until 2023.10.1`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conda-store/conda-store-ui",
-  "version": "2024.10.1",
+  "version": "2024.11.1-dev",
   "description": "UI elements for building a frontend for conda-store",
   "homepage": "https://github.com/conda-incubator/conda-store-ui",
   "bugs": {


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store-ui/issues/434

Now that the release for conda-store-ui is completed, the last step is to bump the package version.

