### PR TITLE
Add "canceled" build status

### DIFF
--- a/src/utils/helpers/buildMapper.ts
+++ b/src/utils/helpers/buildMapper.ts
@@ -5,7 +5,8 @@ const STATUS_OPTIONS: { [key: Build["status"]]: string } = {
   COMPLETED: "Available",
   QUEUED: "Queued",
   FAILED: "Failed",
-  BUILDING: "Building"
+  BUILDING: "Building",
+  CANCELED: "Canceled"
 };
 
 const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -25,7 +26,11 @@ export const buildDatetimeStatus = (
   currentBuildId: number
 ): string => {
   if (id === currentBuildId) {
-    return `${dateToTimezone(ended_on ?? scheduled_on)} - Active`;
+    let option = `${dateToTimezone(ended_on ?? scheduled_on)} - Active`;
+    if (status !== "COMPLETED") {
+      option += " - " + STATUS_OPTIONS[status];
+    }
+    return option;
   } else if (status === "BUILDING") {
     return `${dateToTimezone(scheduled_on)} - Building`;
   } else if (status === "QUEUED") {

--- a/test/helpers/BuildMapper.test.tsx
+++ b/test/helpers/BuildMapper.test.tsx
@@ -32,6 +32,16 @@ describe("buildDatetimeStatus", () => {
     expect(buildDatetimeStatus(build, 2)).toMatch(/Failed$/);
   });
 
+  it("should return canceled build", () => {
+    const build = generateBuild("CANCELED");
+    expect(buildDatetimeStatus(build, 2)).toMatch(/Canceled$/);
+  });
+
+  it("should append canceled to an active build", () => {
+    const build = generateBuild("CANCELED");
+    expect(buildDatetimeStatus(build, build.id)).toMatch(/Active - Canceled$/);
+  });
+
   it("should use the scheduled_on date if the ended_on prop is null", () => {
     const datetimeStatus = buildDatetimeStatus(
       {
@@ -42,5 +52,10 @@ describe("buildDatetimeStatus", () => {
       2
     );
     expect(datetimeStatus).toContain("November 8th, 2022");
+  });
+
+  it("should add tack on additional status if current build has any status other than completed", () => {
+    const build = generateBuild("FAILED");
+    expect(buildDatetimeStatus(build, build.id)).toMatch(/Active - Failed$/);
   });
 });

--- a/test/helpers/BuildMapper.test.tsx
+++ b/test/helpers/BuildMapper.test.tsx
@@ -7,39 +7,34 @@ const generateBuild = (status: string) => ({
 });
 
 describe("buildDatetimeStatus", () => {
-  it("should return an active build", () => {
+  it("should indicate completed build", () => {
     const build = generateBuild("COMPLETED");
-    expect(buildDatetimeStatus(build, 1)).toMatch(/Active$/);
+    expect(buildDatetimeStatus(build, build.id)).toMatch(/Active$/);
+    expect(buildDatetimeStatus(build, -1)).toMatch(/(?<!Active.*)Available$/);
   });
 
-  it("should return build", () => {
+  it("should indicate building build", () => {
     const build = generateBuild("BUILDING");
-    expect(buildDatetimeStatus(build, 2)).toMatch(/Building$/);
+    expect(buildDatetimeStatus(build, build.id)).toMatch(/Active - Building$/);
+    expect(buildDatetimeStatus(build, -1)).toMatch(/(?<!Active.*)Building$/);
   });
 
-  it("should return queued build", () => {
+  it("should indicate queued build", () => {
     const build = generateBuild("QUEUED");
-    expect(buildDatetimeStatus(build, 2)).toMatch(/Queued$/);
+    expect(buildDatetimeStatus(build, build.id)).toMatch(/Active - Queued$/);
+    expect(buildDatetimeStatus(build, -1)).toMatch(/(?<!Active.*)Queued$/);
   });
 
-  it("should return completed build", () => {
-    const build = generateBuild("COMPLETED");
-    expect(buildDatetimeStatus(build, 2)).toMatch(/Available$/);
-  });
-
-  it("should return failed build", () => {
+  it("should indicate failed build", () => {
     const build = generateBuild("FAILED");
-    expect(buildDatetimeStatus(build, 2)).toMatch(/Failed$/);
+    expect(buildDatetimeStatus(build, build.id)).toMatch(/Active - Failed$/);
+    expect(buildDatetimeStatus(build, -1)).toMatch(/(?<!Active.*)Failed$/);
   });
 
-  it("should return canceled build", () => {
-    const build = generateBuild("CANCELED");
-    expect(buildDatetimeStatus(build, 2)).toMatch(/Canceled$/);
-  });
-
-  it("should append canceled to an active build", () => {
+  it("should indicate canceled build", () => {
     const build = generateBuild("CANCELED");
     expect(buildDatetimeStatus(build, build.id)).toMatch(/Active - Canceled$/);
+    expect(buildDatetimeStatus(build, -1)).toMatch(/(?<!Active.*)Canceled$/);
   });
 
   it("should use the scheduled_on date if the ended_on prop is null", () => {
@@ -52,10 +47,5 @@ describe("buildDatetimeStatus", () => {
       2
     );
     expect(datetimeStatus).toContain("November 8th, 2022");
-  });
-
-  it("should add tack on additional status if current build has any status other than completed", () => {
-    const build = generateBuild("FAILED");
-    expect(buildDatetimeStatus(build, build.id)).toMatch(/Active - Failed$/);
   });
 });

--- a/test/playwright/conftest.py
+++ b/test/playwright/conftest.py
@@ -1,15 +1,13 @@
 import pytest
 
-from playwright.sync_api import expect
-
-
 
 def pytest_addoption(parser):
     parser.addoption("--screenshots", action="store", default="false")
 
+
 @pytest.fixture(scope="session")
 def screenshot(pytestconfig):
-    if pytestconfig.getoption("screenshots") == 'false':
+    if pytestconfig.getoption("screenshots") == "false":
         return False
     else:
         return True

--- a/test/playwright/test_ux.py
+++ b/test/playwright/test_ux.py
@@ -2,13 +2,12 @@
 inside and outside of pytest to make future development easier.
 """
 
-import requests
+import random
 import time
 
 import pytest
-from playwright.sync_api import Page, sync_playwright, expect
-import random
-
+import requests
+from playwright.sync_api import Page, expect, sync_playwright
 
 DEFAULT_TIMEOUT = 60_000  # time in ms
 
@@ -93,7 +92,7 @@ def _create_new_environment(page, screenshot=False):
     # add a package to the ui
     page.get_by_label("Enter package").fill("rich")
     page.get_by_role("option", name="rich", exact=True).click()
-    # open up the channels accordian card
+    # open up the channels accordion card
     page.get_by_role("button", name="Channels").click()
     # click the + to add a channel
     page.get_by_role("button", name="+ Add Channel").click()
@@ -105,12 +104,12 @@ def _create_new_environment(page, screenshot=False):
     page.get_by_role("button", name="Create", exact=True).click()
 
     # Interact with the environment shortly after creation
-    # click to open the Active environment dropdown manu
+    # click to open the Active environment dropdown menu
     page.get_by_text(" - Active", exact=False).click()
     # click on the Active environment on the dropdown menu item (which is currently building)
     page.get_by_role("option", name=" - Active", exact=False).click()
     # ensure that the environment is building
-    expect(page.get_by_text("Building")).to_be_visible()
+    expect(page.get_by_test_id("build-status")).to_contain_text("Building", )
     # wait until the status is `Completed`
     completed = page.get_by_text("Completed", exact=False)
     completed.wait_for(state="attached", timeout=time_to_build_env)
@@ -172,7 +171,7 @@ def _existing_environment_interactions(
     # ensure the namespace is expanded
     try:
         expect(env_link).to_be_visible()
-    except Exception as e:
+    except Exception:
         # click to expand the `username` name space (but not click the +)
         page.get_by_role(
             "button", name="username Create a new environment in the username namespace"


### PR DESCRIPTION
## Description

This PR is the front-end companion to the following server PR:

- https://github.com/conda-incubator/conda-store/pull/747

This pull request:

- Adds "CANCELED" status to the front end
- Adds additional status to "Active" build if the build has ended but the status is not "COMPLETED"
  - Rationale: it was weird to me to see a canceled build marked "Active" in the dropdown. Yes, it is the current build, but it's broken and I think this should be a bit more obvious in the UI.

### Screenshots

This screenshot shows how a canceled build appears in the UI. Note that this build is not the current build. The dropdown displays "October 22nd, 2024 - 6:19 PM  - Canceled." And on the next line we have "Status: Canceled":

<img width="581" alt="" src="https://github.com/user-attachments/assets/52eb4ad5-8a66-4e68-8ddb-5571587df3ea">

This screenshot shows how the current build appears in the dropdown if it was canceled. The line for this build in the dropdown displays "October 22nd, 2024 - 5:36 PM - Active - Canceled":

<img width="637" alt="" src="https://github.com/user-attachments/assets/e391bd38-b2df-47a0-8dee-458d961d1ef5">

I want to be clear that I think that this UI is bad. The UI should draw a sharp visual distinction between failed versus successful builds. But the intent of this PR is not to fix the UI, but to at least make it more accurate by reporting a canceled build as canceled rather than ["undefined", as Nikita reported](https://github.com/conda-incubator/conda-store/pull/747#discussion_r1501924878).

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [n/a] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
