### PR TITLE
Bump conda-store server version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   conda-store-worker:
-    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2024.3.1}
+    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2024.11.1}
     volumes:
       - ./docker/assets/environments:/opt/environments:ro
       - ./docker/assets/conda_store_config.py:/opt/conda_store/conda_store_config.py:ro
@@ -16,7 +16,7 @@ services:
       ]
 
   conda-store-server:
-    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2024.3.1}
+    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2024.11.1}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Conda-store 2024.11.1 was recently released. This updates the conda-store-ui docker-compose files to use this most recent version.

ref: https://github.com/conda-incubator/conda-store/issues/967