### PR TITLE
Ensure artifact base url has a trailing slash

### DIFF
--- a/src/utils/helpers/parseArtifactList.ts
+++ b/src/utils/helpers/parseArtifactList.ts
@@ -15,8 +15,8 @@ const isPathAbsolute = (path: string) => {
 
 export const artifactBaseUrl = (apiUrl: string, baseUrl: string) => {
   if (isPathAbsolute(apiUrl)) {
-    return apiUrl;
+    return `${apiUrl}/`;
   } else {
-    return `${baseUrl}${apiUrl}`;
+    return `${baseUrl}${apiUrl}/`;
   }
 };


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/995

## Description
Base url's should have a trailing slash to denote that they are not a relative reference. When there is no trailing slash, using the URL constructor will cause the last part of the path to be cut off.

So, a base url my.server.com/conda-store gets parsed different from my.server.com/conda-store/

ref: https://developer.mozilla.org/en-US/docs/Web/API/URL_API/Resolving_relative_references

So, as an example in `src/features/artifacts/components/ArtifactsItem.tsx` for a Log artifact

```
const baseUrl = "http://localhost:8080/conda-store/"
const route = new URL(artifact.route, baseUrl).toString();
// route is correctly `localhost:8080/conda-store/api/v1/build/<build number>/log`

const baseUrl = "http://localhost:8080/conda-store"
const route = new URL(artifact.route, baseUrl).toString();
// route is incorrectly `localhost:8080/api/v1/build/<build number>/log`
```

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

