### PR TITLE
Always use the latest conda-store unless a version is provided

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   conda-store-worker:
-    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2024.11.1}
+    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-latest}
     volumes:
       - ./docker/assets/environments:/opt/environments:ro
       - ./docker/assets/conda_store_config.py:/opt/conda_store/conda_store_config.py:ro
@@ -16,7 +16,7 @@ services:
       ]
 
   conda-store-server:
-    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-2024.11.1}
+    image: quansight/conda-store-server:${CONDA_STORE_SERVER_VERSION:-latest}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Description
A new version of the conda-store/conda-store-server docker image is pushed to the latest tag whenever a pr is merged to main (on conda-incubator/conda-store).

By setting the default docker compose setup to pull the latest image, developers will always be using the most up to date version of conda-store. Developers can set a specific version they want to test against by setting  `CONDA_STORE_SERVER_VERSION`

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

