### PR TITLE
Add workflows to publish docker container on release

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,11 +1,15 @@
-name: Build Docker image
+name: Docker
+# This workflow builds the conda-store-ui docker image for each
+# pull request. This will ensure that no PR is breaking the docker
+# image, which will be built and pushed to GHCR when a new release
+# is cut.
 
 on:
   pull_request:
 
 jobs:
   build_docker_image:
-    name: "Build Docker Images 🛠"
+    name: "Build Docker Image 🛠"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository 🛎"
@@ -14,7 +18,7 @@ jobs:
       - name: "Set up Docker Buildx 🏗"
         uses: docker/setup-buildx-action@v3
 
-      - name: "Build Docker image 🚀"
+      - name: "Build image 🚀"
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,22 @@
+name: Build Docker image
+
+on:
+  pull_request:
+
+jobs:
+  build_docker_image:
+    name: "Build Docker Images 🛠"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository 🛎"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx 🏗"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build Docker image 🚀"
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: "prod"
+          push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,7 @@ jobs:
 
   build_and_push_docker_image:
     name: "Build Docker Images 🛠"
+    if: github.repository_owner == 'conda-incubator' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: release-to-npmjs
     permissions:
@@ -198,6 +199,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-name: ${{ env.GH_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
 env:
   FORCE_COLOR: "1"
   PACKAGE_FILE: "conda-store-ui.tgz"
+  GH_CONTAINER_REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   # always build and verify
@@ -145,3 +147,57 @@ jobs:
           npm publish --verbose --access public ${{ env.PACKAGE_FILE }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  build_and_push_docker_image:
+    name: "Build Docker Images 🛠"
+    runs-on: ubuntu-latest
+    needs: release-to-npmjs
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: read
+      packages: write
+      attestations: write
+    steps:
+      - name: "Checkout Repository 🛎"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx 🏗"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Login to GH Container Registry 🐳"
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GH_CONTAINER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Add Docker metadata 📝"
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GH_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch
+            type=sha
+
+      - name: "Publish Docker image 🚀"
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: "prod"
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build_and_push_docker_image:
-    name: "Build Docker Images 🛠"
+    name: "Push Docker Images 🛠"
     if: github.repository_owner == 'conda-incubator' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: release-to-npmjs
@@ -178,6 +178,11 @@ jobs:
         with:
           images: |
             ${{ env.GH_CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}
+          # ref: https://github.com/docker/metadata-action?tab=readme-ov-file#typeref
+          # create tags for:
+          #  * the GH tag (eg. 2025.1.8)
+          #  * the branch (eg. main)
+          #  * the commit sha (eg. sha-860c190)
           tags: |
             type=ref,event=tag
             type=ref,event=branch
@@ -193,6 +198,7 @@ jobs:
             ${{ steps.meta.outputs.tags }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
+          # ref https://docs.docker.com/build/ci/github-actions/cache/
           cache-from: type=gha
           cache-to: type=gha,mode=max
       

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,8 @@
 1. Create a new branch for the release `git checkout -b release-2024.9.1`
 1. Clean the branch `git clean -fxdq`
 1. Increment the version in `package.json` following our [version specification](https://conda.store/community/maintenance/release/#calver-details)
+
+## Part 1: Build and release the npm package
 1. Build the package locally:
 
    ```bash
@@ -34,6 +36,21 @@
    ```
 
 If the dry run looks good, continue with the release checklist items.
+
+## Part 2: Build and release the docker image
+
+1. Build the docker image:
+
+  ```bash
+  docker build -t conda-incubator/conda-store-ui:<release version - eg. 2024.11.1> --target prod . 
+  ```
+
+2. Push the image to [GitHub's container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#pushing-container-images)
+
+  ```bash
+  # ensure you are authenticated with github
+  docker push ghcr.io/conda-incubator/conda-store-ui:<release version - eg. 2024.11.1>
+  ```
 
 ## Troubleshooting notes
 


### PR DESCRIPTION
follow up to https://github.com/conda-incubator/conda-store-ui/pull/450

## Description
This PR adds 2 new GHA workflows:
* build docker image (on every pull request)
* adds building+publishing docker image to GH container registry as part of the release workflow

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
